### PR TITLE
레이블 데이터구조 설계 및 String -> UIColor 변환 extension 구현

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -8,9 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		60D4FF13E042363CE8805B41 /* Pods_IssueTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF5A0B739C1DAF0771E82345 /* Pods_IssueTracker.framework */; };
+		95C2F8952547EBE0006B3BC6 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F8942547EBE0006B3BC6 /* Label.swift */; };
+		95C2F8962547EBE0006B3BC6 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F8942547EBE0006B3BC6 /* Label.swift */; };
 		95E9F57C2546EC07001FBA0D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F57B2546EC07001FBA0D /* AppDelegate.swift */; };
 		95E9F57E2546EC07001FBA0D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F57D2546EC07001FBA0D /* SceneDelegate.swift */; };
-		95E9F5802546EC07001FBA0D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F57F2546EC07001FBA0D /* ViewController.swift */; };
+		95E9F5802546EC07001FBA0D /* LabelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F57F2546EC07001FBA0D /* LabelListViewController.swift */; };
 		95E9F5832546EC07001FBA0D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95E9F5812546EC07001FBA0D /* Main.storyboard */; };
 		95E9F5852546EC0C001FBA0D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 95E9F5842546EC0C001FBA0D /* Assets.xcassets */; };
 		95E9F5882546EC0C001FBA0D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95E9F5862546EC0C001FBA0D /* LaunchScreen.storyboard */; };
@@ -33,10 +35,11 @@
 		0109B64F210AD3E237D228DA /* Pods_IssueTrackerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IssueTrackerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F538126B46A1B17CF926A6A /* Pods-IssueTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.debug.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		2E821A460A4A5DD482366AE3 /* Pods-IssueTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.release.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.release.xcconfig"; sourceTree = "<group>"; };
+		95C2F8942547EBE0006B3BC6 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
 		95E9F5782546EC06001FBA0D /* IssueTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IssueTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		95E9F57B2546EC07001FBA0D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95E9F57D2546EC07001FBA0D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		95E9F57F2546EC07001FBA0D /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		95E9F57F2546EC07001FBA0D /* LabelListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelListViewController.swift; sourceTree = "<group>"; };
 		95E9F5822546EC07001FBA0D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		95E9F5842546EC0C001FBA0D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		95E9F5872546EC0C001FBA0D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -79,6 +82,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		95C2F8932547EBD1006B3BC6 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				95C2F8942547EBE0006B3BC6 /* Label.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		95E9F56F2546EC06001FBA0D = {
 			isa = PBXGroup;
 			children = (
@@ -103,9 +114,10 @@
 		95E9F57A2546EC06001FBA0D /* IssueTracker */ = {
 			isa = PBXGroup;
 			children = (
+				95C2F8932547EBD1006B3BC6 /* Model */,
 				95E9F57B2546EC07001FBA0D /* AppDelegate.swift */,
 				95E9F57D2546EC07001FBA0D /* SceneDelegate.swift */,
-				95E9F57F2546EC07001FBA0D /* ViewController.swift */,
+				95E9F57F2546EC07001FBA0D /* LabelListViewController.swift */,
 				95E9F5812546EC07001FBA0D /* Main.storyboard */,
 				95E9F5842546EC0C001FBA0D /* Assets.xcassets */,
 				95E9F5862546EC0C001FBA0D /* LaunchScreen.storyboard */,
@@ -281,7 +293,7 @@
 		};
 		9613C12C2547B1F5005EF13C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			files = (
 			);
 			inputFileListPaths = (
@@ -292,7 +304,7 @@
 			);
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# SwiftLint\n${PODS_ROOT}/SwiftLint/swiftlint\n# SwiftGen\nif [[ -f \"${PODS_ROOT}/SwiftGen/bin/swiftgen\" ]]; then\n  \"${PODS_ROOT}/SwiftGen/bin/swiftgen\" …\nelse\n  echo \"warning: SwiftGen is not installed. Run 'pod install --repo-update' to install it.\"\nfi\n";
 		};
@@ -303,8 +315,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				95E9F5802546EC07001FBA0D /* ViewController.swift in Sources */,
+				95E9F5802546EC07001FBA0D /* LabelListViewController.swift in Sources */,
 				95E9F57C2546EC07001FBA0D /* AppDelegate.swift in Sources */,
+				95C2F8952547EBE0006B3BC6 /* Label.swift in Sources */,
 				95E9F57E2546EC07001FBA0D /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -313,6 +326,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95C2F8962547EBE0006B3BC6 /* Label.swift in Sources */,
 				95E9F5932546EC0C001FBA0D /* IssueTrackerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -10,13 +10,16 @@
 		60D4FF13E042363CE8805B41 /* Pods_IssueTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF5A0B739C1DAF0771E82345 /* Pods_IssueTracker.framework */; };
 		95C2F8952547EBE0006B3BC6 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F8942547EBE0006B3BC6 /* Label.swift */; };
 		95C2F8962547EBE0006B3BC6 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F8942547EBE0006B3BC6 /* Label.swift */; };
+		95C2F8982547EDC7006B3BC6 /* ColorConvertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F8972547EDC7006B3BC6 /* ColorConvertTests.swift */; };
+		95C2F89C2547EF47006B3BC6 /* String+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F89B2547EF47006B3BC6 /* String+Color.swift */; };
+		95C2F89D2547EF47006B3BC6 /* String+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F89B2547EF47006B3BC6 /* String+Color.swift */; };
 		95E9F57C2546EC07001FBA0D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F57B2546EC07001FBA0D /* AppDelegate.swift */; };
 		95E9F57E2546EC07001FBA0D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F57D2546EC07001FBA0D /* SceneDelegate.swift */; };
 		95E9F5802546EC07001FBA0D /* LabelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F57F2546EC07001FBA0D /* LabelListViewController.swift */; };
 		95E9F5832546EC07001FBA0D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95E9F5812546EC07001FBA0D /* Main.storyboard */; };
 		95E9F5852546EC0C001FBA0D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 95E9F5842546EC0C001FBA0D /* Assets.xcassets */; };
 		95E9F5882546EC0C001FBA0D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95E9F5862546EC0C001FBA0D /* LaunchScreen.storyboard */; };
-		95E9F5932546EC0C001FBA0D /* IssueTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F5922546EC0C001FBA0D /* IssueTrackerTests.swift */; };
+		95E9F5932546EC0C001FBA0D /* LabelModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F5922546EC0C001FBA0D /* LabelModelTests.swift */; };
 		9613C12E2547B265005EF13C /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 9613C12D2547B265005EF13C /* .swiftlint.yml */; };
 		D2C7CE68FC3C8579A64346BE /* Pods_IssueTrackerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0109B64F210AD3E237D228DA /* Pods_IssueTrackerTests.framework */; };
 /* End PBXBuildFile section */
@@ -36,6 +39,8 @@
 		1F538126B46A1B17CF926A6A /* Pods-IssueTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.debug.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		2E821A460A4A5DD482366AE3 /* Pods-IssueTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.release.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.release.xcconfig"; sourceTree = "<group>"; };
 		95C2F8942547EBE0006B3BC6 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
+		95C2F8972547EDC7006B3BC6 /* ColorConvertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorConvertTests.swift; sourceTree = "<group>"; };
+		95C2F89B2547EF47006B3BC6 /* String+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Color.swift"; sourceTree = "<group>"; };
 		95E9F5782546EC06001FBA0D /* IssueTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IssueTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		95E9F57B2546EC07001FBA0D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95E9F57D2546EC07001FBA0D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -45,7 +50,7 @@
 		95E9F5872546EC0C001FBA0D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		95E9F5892546EC0C001FBA0D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		95E9F58E2546EC0C001FBA0D /* IssueTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IssueTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		95E9F5922546EC0C001FBA0D /* IssueTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTrackerTests.swift; sourceTree = "<group>"; };
+		95E9F5922546EC0C001FBA0D /* LabelModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelModelTests.swift; sourceTree = "<group>"; };
 		95E9F5942546EC0C001FBA0D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9613C12D2547B265005EF13C /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		B9280E9634EEE3C0BADC1EBF /* Pods-IssueTrackerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTrackerTests.release.xcconfig"; path = "Target Support Files/Pods-IssueTrackerTests/Pods-IssueTrackerTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -122,6 +127,7 @@
 				95E9F5842546EC0C001FBA0D /* Assets.xcassets */,
 				95E9F5862546EC0C001FBA0D /* LaunchScreen.storyboard */,
 				95E9F5892546EC0C001FBA0D /* Info.plist */,
+				95C2F89B2547EF47006B3BC6 /* String+Color.swift */,
 			);
 			path = IssueTracker;
 			sourceTree = "<group>";
@@ -129,7 +135,8 @@
 		95E9F5912546EC0C001FBA0D /* IssueTrackerTests */ = {
 			isa = PBXGroup;
 			children = (
-				95E9F5922546EC0C001FBA0D /* IssueTrackerTests.swift */,
+				95C2F8972547EDC7006B3BC6 /* ColorConvertTests.swift */,
+				95E9F5922546EC0C001FBA0D /* LabelModelTests.swift */,
 				95E9F5942546EC0C001FBA0D /* Info.plist */,
 			);
 			path = IssueTrackerTests;
@@ -315,6 +322,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95C2F89C2547EF47006B3BC6 /* String+Color.swift in Sources */,
 				95E9F5802546EC07001FBA0D /* LabelListViewController.swift in Sources */,
 				95E9F57C2546EC07001FBA0D /* AppDelegate.swift in Sources */,
 				95C2F8952547EBE0006B3BC6 /* Label.swift in Sources */,
@@ -327,7 +335,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				95C2F8962547EBE0006B3BC6 /* Label.swift in Sources */,
-				95E9F5932546EC0C001FBA0D /* IssueTrackerTests.swift in Sources */,
+				95C2F8982547EDC7006B3BC6 /* ColorConvertTests.swift in Sources */,
+				95E9F5932546EC0C001FBA0D /* LabelModelTests.swift in Sources */,
+				95C2F89D2547EF47006B3BC6 /* String+Color.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2Im-NR-0j4">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2Im-NR-0j4">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--레이블-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="LabelListViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="레이블" image="2.circle.fill" catalog="system" id="NXm-Dv-qAK"/>
                 </viewController>
@@ -31,6 +28,7 @@
                 <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="2Im-NR-0j4" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="JdK-uf-RIy">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
@@ -45,8 +43,5 @@
     </scenes>
     <resources>
         <image name="2.circle.fill" catalog="system" width="128" height="121"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/iOS/IssueTracker/IssueTracker/LabelListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelListViewController.swift
@@ -8,11 +8,10 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class LabelListViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
 
 

--- a/iOS/IssueTracker/IssueTracker/Model/Label.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/Label.swift
@@ -1,0 +1,15 @@
+//
+//  Label.swift
+//  IssueTracker
+//
+//  Created by sihyung you on 2020/10/27.
+//  Copyright © 2020 IssueTracker-15. All rights reserved.
+//
+
+import Foundation
+
+struct Label {
+    var title: String
+    var description: String
+    var color: String
+}

--- a/iOS/IssueTracker/IssueTracker/String+Color.swift
+++ b/iOS/IssueTracker/IssueTracker/String+Color.swift
@@ -1,0 +1,33 @@
+//
+//  String+Color.swift
+//  IssueTracker
+//
+//  Created by sihyung you on 2020/10/27.
+//  Copyright © 2020 IssueTracker-15. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension String {
+    var color: UIColor {
+        var tempString: String = self
+        
+        if (self.hasPrefix("#")) {
+            tempString.remove(at: tempString.startIndex)
+        }
+        
+        if (tempString.count != 6) {
+            return UIColor.gray
+        }
+        
+        var rgbValue:UInt64 = 0
+        Scanner(string: tempString).scanHexInt64(&rgbValue)
+
+        return UIColor(red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+                       green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+                       blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
+                       alpha: CGFloat(1.0))
+        
+    }
+}

--- a/iOS/IssueTracker/IssueTrackerTests/ColorConvertTests.swift
+++ b/iOS/IssueTracker/IssueTrackerTests/ColorConvertTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+@testable import IssueTracker
 
 class ColorConvertTests: XCTestCase {
 
@@ -18,16 +19,18 @@ class ColorConvertTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testStringToColor() {
+        let colorCode = "#FF5D5D" // 255, 93, 93
+        let color: UIColor = colorCode.color
+        
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        
+        XCTAssertEqual(red, 1)
+        XCTAssertEqual(green, 93/255.0)
+        XCTAssertEqual(Int(blue * 255), 93)
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/iOS/IssueTracker/IssueTrackerTests/ColorConvertTests.swift
+++ b/iOS/IssueTracker/IssueTrackerTests/ColorConvertTests.swift
@@ -1,0 +1,33 @@
+//
+//  ColorConvertTests.swift
+//  IssueTrackerTests
+//
+//  Created by sihyung you on 2020/10/27.
+//  Copyright © 2020 IssueTracker-15. All rights reserved.
+//
+
+import XCTest
+
+class ColorConvertTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/iOS/IssueTracker/IssueTrackerTests/IssueTrackerTests.swift
+++ b/iOS/IssueTracker/IssueTrackerTests/IssueTrackerTests.swift
@@ -18,17 +18,13 @@ class IssueTrackerTests: XCTestCase {
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    
+    func testLabelInit() {
+        let label = Label(title: "title", description: "설명", color: "#ABABAB")
+        
+        XCTAssertEqual(label.title, "title")
+        XCTAssertEqual(label.description, "설명")
+        XCTAssertEqual(label.color, "#ABABAB")
     }
 
 }

--- a/iOS/IssueTracker/IssueTrackerTests/IssueTrackerTests.swift
+++ b/iOS/IssueTracker/IssueTrackerTests/IssueTrackerTests.swift
@@ -1,0 +1,29 @@
+//
+//  IssueTrackerTests.swift
+//  IssueTrackerTests
+//
+//  Created by sihyung you on 2020/10/26.
+//  Copyright © 2020 IssueTracker-15. All rights reserved.
+//
+
+import XCTest
+@testable import IssueTracker
+
+class LabelModelTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testLabelInit() {
+        let label = Label(title: "title", description: "설명", color: "#ABABAB")
+        
+        XCTAssertEqual(label.title, "title")
+        XCTAssertEqual(label.description, "설명")
+        XCTAssertEqual(label.color, "#ABABAB")
+    }
+}

--- a/iOS/IssueTracker/IssueTrackerTests/LabelModelTests.swift
+++ b/iOS/IssueTracker/IssueTrackerTests/LabelModelTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import IssueTracker
 
-class IssueTrackerTests: XCTestCase {
+class LabelModelTests: XCTestCase {
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -26,5 +26,4 @@ class IssueTrackerTests: XCTestCase {
         XCTAssertEqual(label.description, "설명")
         XCTAssertEqual(label.color, "#ABABAB")
     }
-
 }


### PR DESCRIPTION
#### Issue Number
Close #18 
Close #19 

### 변경사항
레이블 데이터구조 설계
레이블의 String 타입의 색상 코드를 UIColor 타입으로 변환
테스트코드 작성

레이블 데이터구조 init 테스트 결과
![labelinit-test-result](https://user-images.githubusercontent.com/35067611/97266276-852fc600-186b-11eb-9e3f-263775aefe9a.png)

타입 변환 extension 테스트 결과
![extension-test-result](https://user-images.githubusercontent.com/35067611/97266257-7fd27b80-186b-11eb-96db-e99449c42a42.png)

### 새로운 기능
색상 코드를 갖는 String 타입을 UIColor로 변환

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
