### PR TITLE
레이블 수정/추가 화면 키보드가 textField 가리는 문제 해결

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		95E9F5852546EC0C001FBA0D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 95E9F5842546EC0C001FBA0D /* Assets.xcassets */; };
 		95E9F5882546EC0C001FBA0D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95E9F5862546EC0C001FBA0D /* LaunchScreen.storyboard */; };
 		95E9F5932546EC0C001FBA0D /* LabelModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E9F5922546EC0C001FBA0D /* LabelModelTests.swift */; };
+		95F303762549CA2D00851964 /* LabelSubmitForm+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F303752549CA2D00851964 /* LabelSubmitForm+Keyboard.swift */; };
 		9613C12E2547B265005EF13C /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 9613C12D2547B265005EF13C /* .swiftlint.yml */; };
 		96C734CF2549420000DEC9A4 /* LabelSubmitFormView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 96C734CD254941FF00DEC9A4 /* LabelSubmitFormView.xib */; };
 		96C734D02549420000DEC9A4 /* LabelSubmitFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C734CE254941FF00DEC9A4 /* LabelSubmitFormView.swift */; };
@@ -70,6 +71,7 @@
 		95E9F58E2546EC0C001FBA0D /* IssueTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IssueTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		95E9F5922546EC0C001FBA0D /* LabelModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelModelTests.swift; sourceTree = "<group>"; };
 		95E9F5942546EC0C001FBA0D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		95F303752549CA2D00851964 /* LabelSubmitForm+Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LabelSubmitForm+Keyboard.swift"; sourceTree = "<group>"; };
 		9613C12D2547B265005EF13C /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		96C734CD254941FF00DEC9A4 /* LabelSubmitFormView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LabelSubmitFormView.xib; sourceTree = "<group>"; };
 		96C734CE254941FF00DEC9A4 /* LabelSubmitFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabelSubmitFormView.swift; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 			children = (
 				96C734CD254941FF00DEC9A4 /* LabelSubmitFormView.xib */,
 				96C734CE254941FF00DEC9A4 /* LabelSubmitFormView.swift */,
+				95F303752549CA2D00851964 /* LabelSubmitForm+Keyboard.swift */,
 				95C97281254957E40056ACA1 /* LableSubmitForm+Nibload.swift */,
 			);
 			path = Form;
@@ -446,6 +449,7 @@
 				952FF3D5254805EE0042A96F /* LabelHeader+CollectionView.swift in Sources */,
 				95C97282254957E40056ACA1 /* LableSubmitForm+Nibload.swift in Sources */,
 				96C734D32549444E00DEC9A4 /* LabelListViewModel.swift in Sources */,
+				95F303762549CA2D00851964 /* LabelSubmitForm+Keyboard.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/IssueTracker/IssueTracker/LabelScene/View/Form/LabelSubmitForm+Keyboard.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelScene/View/Form/LabelSubmitForm+Keyboard.swift
@@ -1,0 +1,41 @@
+//
+//  LabelSubmitForm+Keyboard.swift
+//  IssueTracker
+//
+//  Created by sihyung you on 2020/10/29.
+//  Copyright © 2020 IssueTracker-15. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension LabelSubmitFormView {
+    
+    func subscribeNotifications() {
+        self.subscribe(UIResponder.keyboardWillShowNotification, selector: #selector(keyboardWillShowOrHide))
+        self.subscribe(UIResponder.keyboardWillHideNotification, selector: #selector(keyboardWillShowOrHide))
+    }
+    
+    func subscribe(_ notification: NSNotification.Name, selector: Selector) {
+        NotificationCenter.default.addObserver(self, selector: selector, name: notification, object: nil)
+    }
+    
+    @objc func keyboardWillShowOrHide(notification: NSNotification) {
+        if let userInfo = notification.userInfo, let keyboardValue = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as AnyObject).cgRectValue {
+            
+            guard formViewEndPoint == nil else { return }
+            
+            formViewEndPoint = self.formView.frame.origin.y + self.formView.frame.height
+            let moveUpward = formViewEndPoint! - keyboardValue.origin.y
+            if formViewEndPoint! > keyboardValue.origin.y {
+                self.frame.origin.y -= moveUpward
+            }
+        }
+    }
+    
+    @objc func handleTap() {
+        self.endEditing(true)
+        self.frame.origin.y = 0
+        self.formViewEndPoint = nil
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/LabelScene/View/Form/LabelSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelScene/View/Form/LabelSubmitFormView.swift
@@ -21,7 +21,7 @@ class LabelSubmitFormView: UIView {
     
     func configure(labelViewModel: LabelItemViewModel? = nil) {
         configureTapGesture()
-        subscribeNotificationForKeyboardBehaviors()
+        subscribeNotifications()
         
         hexCodeField.delegate = self
         
@@ -36,18 +36,11 @@ class LabelSubmitFormView: UIView {
         colorView.layer.backgroundColor = hexCodeField.text?.color
     }
     
-    private func subscribeNotificationForKeyboardBehaviors() {
-        // subscribe to a Notification which will fire before the keyboard will show
-        subscribeToNotification(UIResponder.keyboardWillShowNotification, selector: #selector(keyboardWillShowOrHide))
-        
-        // subscribe to a Notification which will fire before the keyboard will hide
-        subscribeToNotification(UIResponder.keyboardWillHideNotification, selector: #selector(keyboardWillShowOrHide))
+    private func subscribeNotifications() {
+        self.subscribe(UIResponder.keyboardWillShowNotification, selector: #selector(keyboardWillShowOrHide))
+        self.subscribe(UIResponder.keyboardWillHideNotification, selector: #selector(keyboardWillShowOrHide))
     }
-    
-    private func subscribeToNotification(_ notification: NSNotification.Name, selector: Selector) {
-        NotificationCenter.default.addObserver(self, selector: selector, name: notification, object: nil)
-    }
-    
+
     @objc func keyboardWillShowOrHide(notification: NSNotification) {
         if let userInfo = notification.userInfo, let keyboardValue = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as AnyObject).cgRectValue {
             
@@ -112,5 +105,11 @@ class LabelSubmitFormView: UIView {
 extension LabelSubmitFormView: UITextFieldDelegate {
     func textFieldDidEndEditing(_ textField: UITextField) {
         colorView.layer.backgroundColor = hexCodeField.text?.color
+    }
+}
+
+extension LabelSubmitFormView {
+    func subscribe(_ notification: NSNotification.Name, selector: Selector) {
+        NotificationCenter.default.addObserver(self, selector: selector, name: notification, object: nil)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/LabelScene/View/Form/LabelSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelScene/View/Form/LabelSubmitFormView.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 class LabelSubmitFormView: UIView {
+    var formViewEndPoint: CGFloat?
     var submitbuttonTapped: ((String, String, String) -> Void)?
     @IBOutlet weak var backgroundView: UIView!
     @IBOutlet weak var formView: UIView!
@@ -17,7 +18,6 @@ class LabelSubmitFormView: UIView {
     @IBOutlet weak var hexCodeField: UITextField!
     @IBOutlet weak var colorView: UIView!
     private let defaultColorCode: String = "#000000"
-    private var formViewEndPoint: CGFloat?
     
     func configure(labelViewModel: LabelItemViewModel? = nil) {
         configureTapGesture()
@@ -36,34 +36,8 @@ class LabelSubmitFormView: UIView {
         colorView.layer.backgroundColor = hexCodeField.text?.color
     }
     
-    private func subscribeNotifications() {
-        self.subscribe(UIResponder.keyboardWillShowNotification, selector: #selector(keyboardWillShowOrHide))
-        self.subscribe(UIResponder.keyboardWillHideNotification, selector: #selector(keyboardWillShowOrHide))
-    }
-
-    @objc func keyboardWillShowOrHide(notification: NSNotification) {
-        if let userInfo = notification.userInfo, let keyboardValue = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as AnyObject).cgRectValue {
-            
-            guard formViewEndPoint == nil else { return }
-            
-            formViewEndPoint = self.formView.frame.origin.y + self.formView.frame.height
-            let moveUpward = formViewEndPoint! - keyboardValue.origin.y
-            if formViewEndPoint! > keyboardValue.origin.y {
-                self.frame.origin.y -= moveUpward
-            }
-        }
-    }
-    
     private func configureTapGesture() {
-        let tapGesture = UITapGestureRecognizer(target: self,
-                                                action: #selector(handleTap))
-        self.addGestureRecognizer(tapGesture)
-    }
-    
-    @objc func handleTap() {
-        self.endEditing(true)
-        self.frame.origin.y = 0
-        self.formViewEndPoint = nil
+        self.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
     }
     
     @IBAction func refreshColorTapped(_ sender: UIButton) {
@@ -105,11 +79,5 @@ class LabelSubmitFormView: UIView {
 extension LabelSubmitFormView: UITextFieldDelegate {
     func textFieldDidEndEditing(_ textField: UITextField) {
         colorView.layer.backgroundColor = hexCodeField.text?.color
-    }
-}
-
-extension LabelSubmitFormView {
-    func subscribe(_ notification: NSNotification.Name, selector: Selector) {
-        NotificationCenter.default.addObserver(self, selector: selector, name: notification, object: nil)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/LabelScene/View/LabelListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/LabelScene/View/LabelListViewController.swift
@@ -9,10 +9,8 @@
 import UIKit
 
 class LabelListViewController: UIViewController {
-    
     @IBOutlet weak var headerLabel: UILabel!
     @IBOutlet weak var collectionView: UICollectionView!
-    
     private var labelListViewModel: LabelListViewModelProtocol = LabelListViewModel()
     
     override func viewDidLoad() {


### PR DESCRIPTION
### 변경사항
기존의 레이블 수정/추가 화면에서 키보드가 textField를 가렸던 문제를 해결함

### 새로운 기능
최초로 키보드가 formView를 가리는 순간에 가린만큼 View를 올려서 다음 textField edit 시에는 더 이상 조정하지 않아도 되도록 구현
키보드가 내려갈 때 다시 formView의 endpoint를 최초 상태로 돌려놓음

|Before|After|
|------|---|
|![keyboard-before](https://user-images.githubusercontent.com/35067611/97456125-e646bf00-197b-11eb-995d-3c1e1c565795.gif)|![keyboard-after](https://user-images.githubusercontent.com/35067611/97456105-e050de00-197b-11eb-9bba-319c04a07e75.gif)|

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
