### PR TITLE
UILabel+  autoResizeFontWithHeight

### DIFF
--- a/iOS/IssueTracker/IssueTracker/03.MilestoneScene/View/MilestoneCell/MilestoneCellView.swift
+++ b/iOS/IssueTracker/IssueTracker/03.MilestoneScene/View/MilestoneCell/MilestoneCellView.swift
@@ -19,10 +19,10 @@ class MilestoneCellView: UICollectionViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        descriptionLabel.configureFontSize()
-        dateLabel.configureFontSize()
-        openedIssueLabel.configureFontSize()
-        closedIssueLabel.configureFontSize()
+        descriptionLabel.autoResizeFontWithHeight()
+        dateLabel.autoResizeFontWithHeight()
+        openedIssueLabel.autoResizeFontWithHeight()
+        closedIssueLabel.autoResizeFontWithHeight()
     }
     
     func configure(with currentItem: MilestoneItemViewModel) {

--- a/iOS/IssueTracker/IssueTracker/05.CustomUI/BadgeLabelView.swift
+++ b/iOS/IssueTracker/IssueTracker/05.CustomUI/BadgeLabelView.swift
@@ -38,7 +38,7 @@ class BadgeLabelView: UILabel {
         let boundSize = CGSize(width: intrinsicContentSize.width, height: bounds.height)
         bounds = CGRect(origin: boundOrigin, size: boundSize)
         layer.cornerRadius = bounds.height / 2 * cornerRadiusRatio
-        font = font.withSize(boundSize.height - padding.top - padding.bottom)
+        autoResizeFontWithHeight()
     }
 
 }

--- a/iOS/IssueTracker/IssueTracker/06.Extensions/UILabel+FontSize.swift
+++ b/iOS/IssueTracker/IssueTracker/06.Extensions/UILabel+FontSize.swift
@@ -9,7 +9,20 @@
 import UIKit
 
 extension UILabel {
-    func configureFontSize() {
-        self.font = self.font.withSize(self.bounds.height - 1)
+    func autoResizeFontWithHeight() {
+        font = font.withSize(self.adjustedFontSizeWithHeight())
+    }
+    
+    func adjustedFontSizeWithHeight() -> CGFloat {
+        guard let textSize = text?.size(withAttributes: [.font: font!]),
+            textSize.height > bounds.height else {
+                return font.pointSize
+        }
+        
+        let numOfLines = numberOfLines > 0 ? CGFloat(numberOfLines) : 1
+        let scale = bounds.height / (textSize.height * numOfLines)
+        let actualFontSize = scale * font.pointSize
+        
+        return actualFontSize
     }
 }

--- a/iOS/IssueTracker/IssueTracker/06.Extensions/UILabel+FontSize.swift
+++ b/iOS/IssueTracker/IssueTracker/06.Extensions/UILabel+FontSize.swift
@@ -14,10 +14,7 @@ extension UILabel {
     }
     
     func adjustedFontSizeWithHeight() -> CGFloat {
-        guard let textSize = text?.size(withAttributes: [.font: font!]),
-            textSize.height > bounds.height else {
-                return font.pointSize
-        }
+        guard let textSize = text?.size(withAttributes: [.font: font!]) else { return font.pointSize }
         
         let numOfLines = numberOfLines > 0 ? CGFloat(numberOfLines) : 1
         let scale = bounds.height / (textSize.height * numOfLines)


### PR DESCRIPTION
### Issue Number
Close #

### 변경사항

- 06.Extension/UILabel+FontSize 
configureFontSize() -> autoResizeFontWithHeight() 로 명칭 변경
adjustedFontSizeWithHeight() 함수 추가

### 새로운 기능

- ygj 등 baseline 하단으로 내려가는 text도 짤리지 않고 잘 나올 수 있도록 보강
- Label의 NumberOfLines 변수에 따라 정해진 UILabel의 높이 값에 맞게 Font의 크기를 변경

<system font numberOfLines = 2, 3 실행화면>
<p>
<img src="https://user-images.githubusercontent.com/34773827/97772287-0f886a80-1b89-11eb-90d3-9edd2cebb7d0.png" height = 100px>
<img src="https://user-images.githubusercontent.com/34773827/97772299-2b8c0c00-1b89-11eb-92e3-b2da45a75848.png" height = 100px> 
</p>

<custom font Zapfino numberOfLines = 1, 2 실행화면>
<p>
<img src="https://user-images.githubusercontent.com/34773827/97772612-195f9d00-1b8c-11eb-9bdd-8d04df666cf5.png" height = 100px>
<img src="https://user-images.githubusercontent.com/34773827/97772631-3d22e300-1b8c-11eb-9708-0e4ce92cd7c0.png" height = 100px> 
</p>

### 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
