### PR TITLE
keyboard에 따른 view위치 조정 기능, showAlert 함수 기능 일부 변경

### DIFF
--- a/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitForm+Keyboard.swift
+++ b/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitForm+Keyboard.swift
@@ -33,7 +33,7 @@ extension LabelSubmitFormView {
         }
     }
     
-    @objc func handleTap() {
+    @objc func formViewTapped() {
         self.endEditing(true)
         self.frame.origin.y = 0
         self.formViewEndPoint = nil

--- a/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitForm+Keyboard.swift
+++ b/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitForm+Keyboard.swift
@@ -39,5 +39,6 @@ extension LabelSubmitFormView {
         
         guard let moveUpward = moveUpward else { return }
         formView.frame.origin.y += moveUpward
+        self.moveUpward = nil
     }
 }

--- a/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitForm+Keyboard.swift
+++ b/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitForm+Keyboard.swift
@@ -25,9 +25,11 @@ extension LabelSubmitFormView {
             
             guard formViewEndPoint == nil else { return }
             
-            formViewEndPoint = self.formView.frame.origin.y + self.formView.frame.height
-            moveUpward = formViewEndPoint! - keyboardValue.origin.y
-            if formViewEndPoint! > keyboardValue.origin.y, let moveUpward = moveUpward {
+            let newEndPoint = self.formView.frame.origin.y + self.formView.frame.height
+            formViewEndPoint = newEndPoint
+            
+            moveUpward = newEndPoint - keyboardValue.origin.y
+            if newEndPoint > keyboardValue.origin.y {
                 formView.frame.origin.y -= moveUpward
             }
         }
@@ -37,8 +39,7 @@ extension LabelSubmitFormView {
         self.endEditing(true)
         self.formViewEndPoint = nil
         
-        guard let moveUpward = moveUpward else { return }
         formView.frame.origin.y += moveUpward
-        self.moveUpward = nil
+        self.moveUpward = 0
     }
 }

--- a/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitForm+Keyboard.swift
+++ b/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitForm+Keyboard.swift
@@ -26,16 +26,18 @@ extension LabelSubmitFormView {
             guard formViewEndPoint == nil else { return }
             
             formViewEndPoint = self.formView.frame.origin.y + self.formView.frame.height
-            let moveUpward = formViewEndPoint! - keyboardValue.origin.y
-            if formViewEndPoint! > keyboardValue.origin.y {
-                self.frame.origin.y -= moveUpward
+            moveUpward = formViewEndPoint! - keyboardValue.origin.y
+            if formViewEndPoint! > keyboardValue.origin.y, let moveUpward = moveUpward {
+                formView.frame.origin.y -= moveUpward
             }
         }
     }
     
     @objc func formViewTapped() {
         self.endEditing(true)
-        self.frame.origin.y = 0
         self.formViewEndPoint = nil
+        
+        guard let moveUpward = moveUpward else { return }
+        formView.frame.origin.y += moveUpward
     }
 }

--- a/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitFormView.swift
@@ -60,8 +60,18 @@ class LabelSubmitFormView: UIView {
             saveButtonTapped?(titleText, descText, hexCodeText)
             self.removeFromSuperview()
         } else {
-            self.showAlert(title: "제목, 설명, 색상을\n모두 입력해주세요!")
+            self.showAlert(title: "제목, 설명, 색상을\n모두 입력해주세요!", prepare: movewFormViewDownward, completion: moveFormViewUpward)
         }
+    }
+    
+    private func moveFormViewUpward() {
+        guard let moveUpward = moveUpward else { return }
+        formView.frame.origin.y -= moveUpward
+    }
+    
+    private func movewFormViewDownward() {
+        guard let moveUpward = moveUpward else { return }
+        formView.frame.origin.y += moveUpward
     }
     
     @IBAction func resetFormButtonTapped(_ sender: UIButton) {
@@ -85,3 +95,8 @@ extension LabelSubmitFormView: UITextFieldDelegate {
         colorView.layer.backgroundColor = hexCodeField.text?.color
     }
 }
+
+    enum MovingFormView {
+        case up
+        case down
+    }

--- a/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitFormView.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class LabelSubmitFormView: UIView {
     var formViewEndPoint: CGFloat?
+    var moveUpward: CGFloat?
     var saveButtonTapped: ((String, String, String) -> Void)?
     @IBOutlet weak var backgroundView: UIView!
     @IBOutlet weak var formView: UIView!

--- a/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitFormView.swift
@@ -37,7 +37,7 @@ class LabelSubmitFormView: UIView {
     }
     
     private func configureTapGesture() {
-        self.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
+        formView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(formViewTapped)))
         backgroundView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(backgroundTapped)))
     }
     

--- a/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/02.LabelScene/View/SubmitForm/LabelSubmitFormView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class LabelSubmitFormView: UIView {
     var formViewEndPoint: CGFloat?
-    var moveUpward: CGFloat?
+    var moveUpward: CGFloat = 0
     var saveButtonTapped: ((String, String, String) -> Void)?
     @IBOutlet weak var backgroundView: UIView!
     @IBOutlet weak var formView: UIView!
@@ -65,12 +65,10 @@ class LabelSubmitFormView: UIView {
     }
     
     private func moveFormViewUpward() {
-        guard let moveUpward = moveUpward else { return }
         formView.frame.origin.y -= moveUpward
     }
     
     private func movewFormViewDownward() {
-        guard let moveUpward = moveUpward else { return }
         formView.frame.origin.y += moveUpward
     }
     
@@ -95,8 +93,3 @@ extension LabelSubmitFormView: UITextFieldDelegate {
         colorView.layer.backgroundColor = hexCodeField.text?.color
     }
 }
-
-    enum MovingFormView {
-        case up
-        case down
-    }

--- a/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitForm+Keyboard.swift
+++ b/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitForm+Keyboard.swift
@@ -25,9 +25,11 @@ extension MilestoneSubmitFormView {
             
             guard formViewEndPoint == nil else { return }
             
-            formViewEndPoint = self.formView.frame.origin.y + self.formView.frame.height
-            moveUpward = formViewEndPoint! - keyboardValue.origin.y
-            if formViewEndPoint! > keyboardValue.origin.y, let moveUpward = moveUpward {
+            let newEndPoint = self.formView.frame.origin.y + self.formView.frame.height
+            formViewEndPoint = newEndPoint
+            
+            moveUpward = newEndPoint - keyboardValue.origin.y
+            if newEndPoint > keyboardValue.origin.y {
                 formView.frame.origin.y -= moveUpward
             }
         }
@@ -37,8 +39,7 @@ extension MilestoneSubmitFormView {
         self.endEditing(true)
         self.formViewEndPoint = nil
         
-        guard let moveUpward = moveUpward else { return }
         formView.frame.origin.y += moveUpward
-        self.moveUpward = nil
+        self.moveUpward = 0
     }
 }

--- a/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitForm+Keyboard.swift
+++ b/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitForm+Keyboard.swift
@@ -26,16 +26,19 @@ extension MilestoneSubmitFormView {
             guard formViewEndPoint == nil else { return }
             
             formViewEndPoint = self.formView.frame.origin.y + self.formView.frame.height
-            let moveUpward = formViewEndPoint! - keyboardValue.origin.y
-            if formViewEndPoint! > keyboardValue.origin.y {
-                self.frame.origin.y -= moveUpward
+            moveUpward = formViewEndPoint! - keyboardValue.origin.y
+            if formViewEndPoint! > keyboardValue.origin.y, let moveUpward = moveUpward {
+                formView.frame.origin.y -= moveUpward
             }
         }
     }
     
     @objc func formViewTapped() {
         self.endEditing(true)
-        self.frame.origin.y = 0
         self.formViewEndPoint = nil
+        
+        guard let moveUpward = moveUpward else { return }
+        formView.frame.origin.y += moveUpward
+        self.moveUpward = nil
     }
 }

--- a/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitForm+Keyboard.swift
+++ b/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitForm+Keyboard.swift
@@ -33,7 +33,7 @@ extension MilestoneSubmitFormView {
         }
     }
     
-    @objc func handleTap() {
+    @objc func formViewTapped() {
         self.endEditing(true)
         self.frame.origin.y = 0
         self.formViewEndPoint = nil

--- a/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitFormView.swift
@@ -38,12 +38,12 @@ class MilestoneSubmitFormView: UIView {
     
     @IBAction func saveButtonTapped(_ sender: UIButton) {
         guard checkDateFieldValidation() else {
-            self.showAlert(title: "날짜를 양식에 맞게 적어주세요!")
+            self.showAlert(title: "날짜를 양식에 맞게 적어주세요!", prepare: nil, completion: nil)
             return
         }
         
         guard let titleText = titleField.text, !titleText.isEmpty else {
-            self.showAlert(title: "제목은 반드시 입력해야해요!")
+            self.showAlert(title: "제목은 반드시 입력해야해요!", prepare: nil, completion: nil)
             return
         }
         

--- a/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitFormView.swift
@@ -32,7 +32,7 @@ class MilestoneSubmitFormView: UIView {
     }
     
     private func configureTapGesture() {
-        self.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
+        self.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(formViewTapped)))
         backgroundView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(backgroundTapped)))
     }
     

--- a/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitFormView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class MilestoneSubmitFormView: UIView {
     var formViewEndPoint: CGFloat?
-    var moveUpward: CGFloat?
+    var moveUpward: CGFloat = 0
     var saveButtonTapped: ((String, String, String) -> Void)?
     @IBOutlet weak var formView: UIView!
     @IBOutlet weak var backgroundView: UIView!
@@ -39,12 +39,12 @@ class MilestoneSubmitFormView: UIView {
     
     @IBAction func saveButtonTapped(_ sender: UIButton) {
         guard checkDateFieldValidation() else {
-            self.showAlert(title: "날짜를 양식에 맞게 적어주세요!", prepare: movewFormViewDownward, completion: moveFormViewUpward)
+            self.showAlert(title: "날짜를 양식에 맞게 적어주세요!", prepare: moveFormViewDownward, completion: moveFormViewUpward)
             return
         }
         
         guard let titleText = titleField.text, !titleText.isEmpty else {
-            self.showAlert(title: "제목은 반드시 입력해야해요!", prepare: movewFormViewDownward, completion: moveFormViewUpward)
+            self.showAlert(title: "제목은 반드시 입력해야해요!", prepare: moveFormViewDownward, completion: moveFormViewUpward)
             return
         }
         
@@ -53,12 +53,10 @@ class MilestoneSubmitFormView: UIView {
     }
     
     private func moveFormViewUpward() {
-        guard let moveUpward = moveUpward else { return }
         formView.frame.origin.y -= moveUpward
     }
     
-    private func movewFormViewDownward() {
-        guard let moveUpward = moveUpward else { return }
+    private func moveFormViewDownward() {
         formView.frame.origin.y += moveUpward
     }
     

--- a/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/03.MilestoneScene/SubmitForm/MilestoneSubmitFormView.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class MilestoneSubmitFormView: UIView {
     var formViewEndPoint: CGFloat?
+    var moveUpward: CGFloat?
     var saveButtonTapped: ((String, String, String) -> Void)?
     @IBOutlet weak var formView: UIView!
     @IBOutlet weak var backgroundView: UIView!
@@ -38,17 +39,27 @@ class MilestoneSubmitFormView: UIView {
     
     @IBAction func saveButtonTapped(_ sender: UIButton) {
         guard checkDateFieldValidation() else {
-            self.showAlert(title: "날짜를 양식에 맞게 적어주세요!", prepare: nil, completion: nil)
+            self.showAlert(title: "날짜를 양식에 맞게 적어주세요!", prepare: movewFormViewDownward, completion: moveFormViewUpward)
             return
         }
         
         guard let titleText = titleField.text, !titleText.isEmpty else {
-            self.showAlert(title: "제목은 반드시 입력해야해요!", prepare: nil, completion: nil)
+            self.showAlert(title: "제목은 반드시 입력해야해요!", prepare: movewFormViewDownward, completion: moveFormViewUpward)
             return
         }
         
         saveButtonTapped?(titleText, descField?.text ?? "", dateField?.text ?? "")
         self.removeFromSuperview()
+    }
+    
+    private func moveFormViewUpward() {
+        guard let moveUpward = moveUpward else { return }
+        formView.frame.origin.y -= moveUpward
+    }
+    
+    private func movewFormViewDownward() {
+        guard let moveUpward = moveUpward else { return }
+        formView.frame.origin.y += moveUpward
     }
     
     @IBAction func resetButtonTapped(_ sender: UIButton) {

--- a/iOS/IssueTracker/IssueTracker/06.Extensions/UIView+ShowAlert.swift
+++ b/iOS/IssueTracker/IssueTracker/06.Extensions/UIView+ShowAlert.swift
@@ -8,13 +8,12 @@
 
 import UIKit
 
-extension UIView {
-    func showAlert(title: String) {
-        let previousFrameOrigin = self.frame.origin.y
-        self.frame.origin.y = 0
+extension UIView {    
+    func showAlert(title: String, prepare: (() -> Void)?, completion: (() -> Void)?) {
+        prepare?()
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { [weak self] (_: UIAlertAction) in
-            self?.frame.origin.y = previousFrameOrigin
+        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { (_: UIAlertAction) in
+            completion?()
         }))
         self.window?.rootViewController?.present(alert, animated: true, completion: nil)
     }


### PR DESCRIPTION
### Issue Number

### 변경사항
1. Tap gesture 감지를 기존에 SubmitFormView 전체 / backgorundView 로 나누어 감지했었으나 backgroundView는 SubmitFormViewdml subview이므로 자연스럽지 않아 형제관계인 formView / backgroundView로 분리하여 감지 (기능에는 변화 x)
2. 키보드로 인해 formView를 올리고 내리는 과정에서 SubmitFormView 전체를 움직이던 구조에서 formView만 움직이도록 변경
SubmitFormView 전체를 움직이면 아래와 같이 backgroundView도 함께 움직이는데 backgroudView는 움직일 필요가 없으므로 키보드로 인해 사용성에 영향을 받는 formView만 움직이도록 변경
![스크린샷 2020-10-31 오후 3 10 43](https://user-images.githubusercontent.com/35067611/97773047-0c44ad00-1b90-11eb-91b6-51457c400622.png)
이 과정에서 formView가 얼마나 움직였는지 파악해놓기 위한 변수가 필요해서 moveUpward를 선언

3. showAlert 함수 기능 축소
showAlert는 전달받은 title을 띄울 뿐이지 기존 구조처럼 내부에서 submitFormView의 origin을 조작하는 것은 부자연스러워, 전달받는 title을 표시하되, formView를 위/아래로 움직여야 한다면 prepare/completion handler를 전달받도록 함수를 변경
prepare이 있는 이유는 alert 창이 뜨면서 키보드가 내려가는데 그 때 formView를 아래로 내리기 위함
completion은 alert의 ok 버튼을 누른 후에 다시 키보드가 올라와야하므로 formView 를 위로 올리기 위함
prepare/compeltion은 모두 optional closure 타입으로 일반적인 showAlert가 필요한 상황이라면 nil로 전달하면 됨

### 새로운 기능

### 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
