### PR TITLE
layoutSubview에서 bounds 호출하던 문제 해결

### DIFF
--- a/iOS/IssueTracker/IssueTracker/05.CustomUI/BadgeLabelView.swift
+++ b/iOS/IssueTracker/IssueTracker/05.CustomUI/BadgeLabelView.swift
@@ -34,10 +34,8 @@ class BadgeLabelView: UILabel {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        let boundOrigin = bounds.origin
         let boundSize = CGSize(width: intrinsicContentSize.width, height: bounds.height)
-        bounds = CGRect(origin: boundOrigin, size: boundSize)
-        layer.cornerRadius = bounds.height / 2 * cornerRadiusRatio
+        layer.cornerRadius = boundSize.height / 2 * cornerRadiusRatio
         autoResizeFontWithHeight()
     }
 


### PR DESCRIPTION
### Issue Number
Close #

### 변경사항
badgeLabel의 layoutSubview 함수에서 bound 변경하던 부분 삭제

### 새로운 기능
layoutSubview에서 bound가 변경되어 계속 layoutsubview가 재호출 되던 문제를 해결하였습니다.

### 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
