### PR TITLE
이슈 상세화면, 댓글 추가화면 데이터 연결 완료

### DIFF
--- a/iOS/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2Im-NR-0j4">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2Im-NR-0j4">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -19,7 +17,7 @@
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="TRp-x7-khU">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="hOc-uy-123">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -29,14 +27,14 @@
                                 <cells/>
                             </collectionView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="YTB-0w-zkd"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="TRp-x7-khU" secondAttribute="trailing" id="Zf6-Wj-gYO"/>
                             <constraint firstItem="TRp-x7-khU" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="kr5-Z9-79b"/>
                             <constraint firstItem="TRp-x7-khU" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="mz3-kn-C60"/>
                             <constraint firstAttribute="bottom" secondItem="TRp-x7-khU" secondAttribute="bottom" id="qt8-Aj-enq"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="YTB-0w-zkd"/>
                     </view>
                     <navigationItem key="navigationItem" title="레이블" id="NjL-aG-9it">
                         <barButtonItem key="rightBarButtonItem" style="done" id="7ln-Zd-Fg5">
@@ -65,8 +63,8 @@
                     <view key="view" contentMode="scaleToFill" id="bvu-0U-8wt">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="G6G-aE-yPu"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="설정" image="4.circle.fill" catalog="system" id="FLg-cc-DFw"/>
                 </viewController>
@@ -84,7 +82,7 @@
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="s3J-Rm-mPR">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="OZP-6Q-hnZ">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -94,14 +92,14 @@
                                 <cells/>
                             </collectionView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="mru-jz-cdO"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="s3J-Rm-mPR" firstAttribute="top" secondItem="QEd-xG-S7R" secondAttribute="top" id="e3s-y9-sQR"/>
                             <constraint firstAttribute="bottom" secondItem="s3J-Rm-mPR" secondAttribute="bottom" id="qtx-X7-7Oc"/>
                             <constraint firstAttribute="trailing" secondItem="s3J-Rm-mPR" secondAttribute="trailing" id="urT-cu-jfP"/>
                             <constraint firstItem="s3J-Rm-mPR" firstAttribute="leading" secondItem="QEd-xG-S7R" secondAttribute="leading" id="vaD-uK-fCS"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="mru-jz-cdO"/>
                     </view>
                     <navigationItem key="navigationItem" title="마일스톤" id="oYc-WB-dqB">
                         <barButtonItem key="rightBarButtonItem" id="aOq-D6-Llh">
@@ -177,7 +175,7 @@
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="MsW-cq-Pbp">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
-                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="HQK-O9-Si0">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -197,12 +195,11 @@
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="large" weight="bold"/>
                                 </state>
                                 <connections>
-                                    <segue destination="24V-yA-fcF" kind="presentation" id="kxg-o8-Tgn"/>
+                                    <action selector="addIssueButtonTapped:" destination="EML-Kz-Cea" eventType="touchUpInside" id="XKx-Fh-3lx"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="bvj-Iu-non"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="MsW-cq-Pbp" firstAttribute="leading" secondItem="WFd-Ro-ELe" secondAttribute="leading" id="5ou-My-cfT"/>
                             <constraint firstItem="bvj-Iu-non" firstAttribute="bottom" secondItem="EVQ-k4-p1T" secondAttribute="bottom" constant="30" id="6RT-pJ-WK0"/>
@@ -212,6 +209,7 @@
                             <constraint firstItem="bvj-Iu-non" firstAttribute="bottom" secondItem="MsW-cq-Pbp" secondAttribute="bottom" id="x24-aC-Bhe"/>
                             <constraint firstItem="EVQ-k4-p1T" firstAttribute="width" secondItem="WFd-Ro-ELe" secondAttribute="width" multiplier="0.125" id="zi2-Uq-BbX"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="bvj-Iu-non"/>
                     </view>
                     <navigationItem key="navigationItem" title="이슈" largeTitleDisplayMode="always" id="b8K-mN-g65">
                         <barButtonItem key="leftBarButtonItem" title="Filter" id="TOO-qs-SZ3">
@@ -243,7 +241,7 @@
                     <tabBarItem key="tabBarItem" title="레이블" image="2.circle.fill" catalog="system" id="NXm-Dv-qAK"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="NKq-kU-VOX">
-                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="104.5"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>
@@ -263,7 +261,7 @@
                     <tabBarItem key="tabBarItem" title="마일스톤" image="3.circle.fill" catalog="system" id="RDq-oe-4vG"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="jZ3-TC-wsS">
-                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="104.5"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>
@@ -276,102 +274,6 @@
             </objects>
             <point key="canvasLocation" x="1076.8115942028987" y="893.97321428571422"/>
         </scene>
-        <!--Add New Issue View Controller-->
-        <scene sceneID="xnh-53-5MK">
-            <objects>
-                <viewController storyboardIdentifier="AddNewIssueViewController" id="Y8p-ie-OWu" customClass="AddNewIssueViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="iVE-nq-huQ">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cYP-py-DgA">
-                                <rect key="frame" x="20" y="144" width="374" height="42"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uNE-Xl-7zb">
-                                <rect key="frame" x="20" y="118" width="374" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.58823529411764708" green="0.58823529411764708" blue="0.58823529411764708" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="ffC-xq-HP2">
-                                <rect key="frame" x="20" y="196" width="374" height="35"/>
-                                <segments>
-                                    <segment title="마크다운"/>
-                                    <segment title="미리보기"/>
-                                </segments>
-                                <connections>
-                                    <action selector="segmentDidChange:" destination="Y8p-ie-OWu" eventType="valueChanged" id="C00-0y-5e3"/>
-                                </connections>
-                            </segmentedControl>
-                        </subviews>
-                        <viewLayoutGuide key="safeArea" id="XOH-zx-EwI"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="XOH-zx-EwI" firstAttribute="trailing" secondItem="cYP-py-DgA" secondAttribute="trailing" constant="20" id="4Xv-Fb-wWv"/>
-                            <constraint firstItem="XOH-zx-EwI" firstAttribute="trailing" secondItem="uNE-Xl-7zb" secondAttribute="trailing" constant="20" id="D8v-ke-tlR"/>
-                            <constraint firstItem="uNE-Xl-7zb" firstAttribute="leading" secondItem="XOH-zx-EwI" secondAttribute="leading" constant="20" id="HoI-7x-9vz"/>
-                            <constraint firstItem="ffC-xq-HP2" firstAttribute="top" secondItem="cYP-py-DgA" secondAttribute="bottom" constant="10" id="OAl-zB-1Ot"/>
-                            <constraint firstItem="cYP-py-DgA" firstAttribute="top" secondItem="uNE-Xl-7zb" secondAttribute="bottom" constant="5" id="OG0-ez-xPR"/>
-                            <constraint firstItem="cYP-py-DgA" firstAttribute="leading" secondItem="XOH-zx-EwI" secondAttribute="leading" constant="20" id="Tdg-Gy-kN4"/>
-                            <constraint firstItem="cYP-py-DgA" firstAttribute="height" secondItem="iVE-nq-huQ" secondAttribute="height" multiplier="0.05" id="Tjy-6E-9hD"/>
-                            <constraint firstItem="ffC-xq-HP2" firstAttribute="height" secondItem="iVE-nq-huQ" secondAttribute="height" multiplier="0.04" id="ZKM-fv-ofD"/>
-                            <constraint firstItem="uNE-Xl-7zb" firstAttribute="top" secondItem="XOH-zx-EwI" secondAttribute="top" constant="10" id="b7o-ff-RG4"/>
-                            <constraint firstItem="ffC-xq-HP2" firstAttribute="leading" secondItem="XOH-zx-EwI" secondAttribute="leading" constant="20" id="dqL-DH-JUs"/>
-                            <constraint firstItem="XOH-zx-EwI" firstAttribute="trailing" secondItem="ffC-xq-HP2" secondAttribute="trailing" constant="20" id="slE-d5-DSA"/>
-                        </constraints>
-                    </view>
-                    <navigationItem key="navigationItem" id="xyz-op-LC6">
-                        <barButtonItem key="leftBarButtonItem" style="done" id="tJ9-WO-SS0">
-                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="1SI-Qo-mgN">
-                                <rect key="frame" x="20" y="13" width="92" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Cancel"/>
-                                <connections>
-                                    <action selector="cancelButtonTapped:" destination="Y8p-ie-OWu" eventType="touchUpInside" id="WVE-Ai-G3E"/>
-                                </connections>
-                            </button>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" id="jJT-Y8-nLZ">
-                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="mc1-Ta-aaw">
-                                <rect key="frame" x="302" y="13" width="92" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Done"/>
-                                <connections>
-                                    <action selector="doneButtonTapped:" destination="Y8p-ie-OWu" eventType="touchUpInside" id="Fw0-8b-Wf3"/>
-                                </connections>
-                            </button>
-                        </barButtonItem>
-                    </navigationItem>
-                    <connections>
-                        <outlet property="segmentedControl" destination="ffC-xq-HP2" id="THk-Jf-wsn"/>
-                        <outlet property="titleTextField" destination="cYP-py-DgA" id="uv5-n6-lP9"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="oeR-Yt-dD7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3683" y="-556"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="TWO-Da-erg">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="24V-yA-fcF" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="kro-Mr-mzO">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="108"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="Y8p-ie-OWu" kind="relationship" relationship="rootViewController" destinationCreationSelector="addIssueSeguePerformed:" id="SHT-mG-O5o"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="gUz-cP-Oom" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2807" y="-556"/>
-        </scene>
     </scenes>
     <resources>
         <image name="1.circle.fill" catalog="system" width="128" height="121"/>
@@ -379,11 +281,5 @@
         <image name="3.circle.fill" catalog="system" width="128" height="121"/>
         <image name="4.circle.fill" catalog="system" width="128" height="121"/>
         <image name="plus" catalog="system" width="128" height="113"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
     </resources>
 </document>

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		956B5D0525503D20001CBAA9 /* MilestoneService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956B5D0425503D20001CBAA9 /* MilestoneService.swift */; };
 		956B5D0725503E8A001CBAA9 /* LabelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956B5D0625503E8A001CBAA9 /* LabelService.swift */; };
 		957D8222255060DA0033484F /* AddNewIssueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957D8220255060DA0033484F /* AddNewIssueViewController.swift */; };
+		95AE90CF25594610002BAE95 /* EditIssue.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95AE90CE25594610002BAE95 /* EditIssue.storyboard */; };
 		95C2F8952547EBE0006B3BC6 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F8942547EBE0006B3BC6 /* Label.swift */; };
 		95C2F8982547EDC7006B3BC6 /* ColorConvertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F8972547EDC7006B3BC6 /* ColorConvertTests.swift */; };
 		95C2F89C2547EF47006B3BC6 /* String+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C2F89B2547EF47006B3BC6 /* String+Color.swift */; };
@@ -210,6 +211,7 @@
 		956B5D0425503D20001CBAA9 /* MilestoneService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneService.swift; sourceTree = "<group>"; };
 		956B5D0625503E8A001CBAA9 /* LabelService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelService.swift; sourceTree = "<group>"; };
 		957D8220255060DA0033484F /* AddNewIssueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddNewIssueViewController.swift; sourceTree = "<group>"; };
+		95AE90CE25594610002BAE95 /* EditIssue.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EditIssue.storyboard; sourceTree = "<group>"; };
 		95C2F8942547EBE0006B3BC6 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
 		95C2F8972547EDC7006B3BC6 /* ColorConvertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorConvertTests.swift; sourceTree = "<group>"; };
 		95C2F89B2547EF47006B3BC6 /* String+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Color.swift"; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 			isa = PBXGroup;
 			children = (
 				957D8220255060DA0033484F /* AddNewIssueViewController.swift */,
+				95AE90CE25594610002BAE95 /* EditIssue.storyboard */,
 			);
 			path = IssueEditScene;
 			sourceTree = "<group>";
@@ -994,6 +997,7 @@
 				963A1AA225524AEC003E2BBB /* MilestoneComponentView.xib in Resources */,
 				961B10602558F39500C7048C /* IssueFilter.storyboard in Resources */,
 				9508B8252552A71A0015C636 /* IssueDetailCellView.xib in Resources */,
+				95AE90CF25594610002BAE95 /* EditIssue.storyboard in Resources */,
 				9613C12E2547B265005EF13C /* .swiftlint.yml in Resources */,
 				95E9F5882546EC0C001FBA0D /* LaunchScreen.storyboard in Resources */,
 				963A1A9E255249BB003E2BBB /* LabelComponentView.xib in Resources */,

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/AddCommentView/AddCommentView.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/AddCommentView/AddCommentView.swift
@@ -8,9 +8,14 @@
 
 import UIKit
 
+protocol AddCommentDelegate: AnyObject {
+    func addCommentButtonTapped()
+    func upButtonTapped()
+    func downButtonTapped()
+}
+
 class AddCommentView: UIView {
-    var upButtonTapped: (() -> Void)?
-    var downButtonTapped: (() -> Void)?
+    weak var addCommentDelegate: AddCommentDelegate?
     @IBOutlet weak var barView: UIView!
     @IBOutlet weak var addCommentButton: UIButton!
     @IBOutlet weak var upButton: UIButton!
@@ -29,6 +34,12 @@ class AddCommentView: UIView {
         let gesture = UIPanGestureRecognizer.init(target: self, action: #selector(self.panGesture))
         self.addGestureRecognizer(gesture)
     }
+    
+    @IBAction func addCommentButtonTapped(_ sender: Any) {
+        // delegate 발동
+        addCommentDelegate?.addCommentButtonTapped()
+    }
+    
 }
 
 // MARK: - loadNIB extension
@@ -66,15 +77,12 @@ extension AddCommentView {
             }, completion: nil)
         }
     }
-    
-    @IBAction func addCommentButtonTapped(_ sender: Any) {
-    }
 
     @IBAction func upButtonTapped(_ sender: Any) {
-        upButtonTapped?()
+        addCommentDelegate?.upButtonTapped()
     }
 
     @IBAction func downButtonTapped(_ sender: Any) {
-        downButtonTapped?()
+        addCommentDelegate?.downButtonTapped()
     }
 }

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/AddCommentView/AddCommentView.xib
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/AddCommentView/AddCommentView.xib
@@ -35,7 +35,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="addCommentButtonTapped:" destination="i5M-Pr-FkT" eventType="touchUpInside" id="wkv-AM-D0j"/>
+                        <action selector="addCommentButtonTapped:" destination="i5M-Pr-FkT" eventType="touchUpInside" id="D3h-Nz-CTB"/>
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nE5-uG-pPY" userLabel="Down Button">

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailCellView.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailCellView.swift
@@ -10,9 +10,15 @@ import UIKit
 
 class IssueDetailCellView: UICollectionViewCell {
        
-    @IBOutlet weak var desc: UILabel!
-    func configure(with text: String) {
-        desc.text = text
+    @IBOutlet weak var content: UILabel!
+    @IBOutlet weak var author: UILabel!
+    @IBOutlet weak var createAt: UILabel!
+    @IBOutlet weak var profilePicture: UIImageView!
+    
+    func configure(with comment: CommentViewModel) {
+        content.text = comment.content
+        author.text = comment.userName
+        createAt.text = comment.createAt
     }
     
     override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailCellView.xib
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailCellView.xib
@@ -82,7 +82,10 @@
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <size key="customSize" width="586" height="523"/>
             <connections>
-                <outlet property="desc" destination="6oD-yh-wAK" id="SjD-jd-dwW"/>
+                <outlet property="author" destination="3vp-g9-v3l" id="cce-nR-BcY"/>
+                <outlet property="content" destination="6oD-yh-wAK" id="SjD-jd-dwW"/>
+                <outlet property="createAt" destination="WMG-Kc-bHQ" id="v4j-iY-3jC"/>
+                <outlet property="profilePicture" destination="gvy-u4-1hO" id="4CT-jJ-SSc"/>
             </connections>
             <point key="canvasLocation" x="518.84057971014499" y="311.71875"/>
         </collectionViewCell>

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailHeaderView.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailHeaderView.swift
@@ -28,13 +28,6 @@ class IssueDetailHeaderView: UICollectionReusableView {
         configureIssueBadge(isOpened: issueDetailViewModel.isOpened)
     }
     
-    override func systemLayoutSizeFitting(_ targetSize: CGSize) -> CGSize {
-        var size = super.systemLayoutSizeFitting(targetSize)
-        size.height += issueTitle.intrinsicContentSize.height
-
-        return size
-    }
-    
     private func configureIssueBadge(isOpened: Bool) {
         var badgeColor: UIColor
         var badgeText: String
@@ -63,4 +56,5 @@ extension UIButton {
         self.backgroundColor = backgroundColor
         self.setTitle(text, for: .normal)
     }
+    
 }

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailHeaderView.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailHeaderView.swift
@@ -15,6 +15,7 @@ enum IssueBadgeColor: String {
 
 class IssueDetailHeaderView: UICollectionReusableView {
     
+    @IBOutlet weak var profilePicture: UIImageView!
     @IBOutlet weak var issueAuthor: UILabel!
     @IBOutlet weak var issueTitle: UILabel!
     @IBOutlet weak var issueNumber: UILabel!
@@ -25,6 +26,13 @@ class IssueDetailHeaderView: UICollectionReusableView {
         self.issueTitle.text = issueDetailViewModel.title
         self.issueNumber.text = "#" + String(issueDetailViewModel.issueNumber)
         configureIssueBadge(isOpened: issueDetailViewModel.isOpened)
+    }
+    
+    override func systemLayoutSizeFitting(_ targetSize: CGSize) -> CGSize {
+        var size = super.systemLayoutSizeFitting(targetSize)
+        size.height += issueTitle.intrinsicContentSize.height
+
+        return size
     }
     
     private func configureIssueBadge(isOpened: Bool) {

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailHeaderView.xib
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailHeaderView.xib
@@ -18,7 +18,7 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이슈 타이틀" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gDF-Uv-gPE" userLabel="Issue Title">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="이슈 타이틀" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gDF-Uv-gPE" userLabel="Issue Title">
                     <rect key="frame" x="10" y="67" width="450" height="139"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                     <nil key="textColor"/>
@@ -39,9 +39,6 @@
                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Yr-oe-ZWr">
                     <rect key="frame" x="10" y="216" width="20" height="22"/>
                     <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="22" id="AjD-FI-4lm"/>
-                    </constraints>
                     <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <state key="normal" image="exclamationmark.circle" catalog="system"/>
                     <userDefinedRuntimeAttributes>

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailHeaderView.xib
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailView/IssueDetailHeaderView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -18,7 +18,7 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="이슈 타이틀" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gDF-Uv-gPE" userLabel="Issue Title">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이슈 타이틀" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gDF-Uv-gPE" userLabel="Issue Title">
                     <rect key="frame" x="10" y="67" width="450" height="139"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                     <nil key="textColor"/>
@@ -36,7 +36,7 @@
                         <constraint firstAttribute="width" secondItem="TIo-KR-UoL" secondAttribute="height" multiplier="1:1" id="G62-jS-SiS"/>
                     </constraints>
                 </imageView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Yr-oe-ZWr">
+                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Yr-oe-ZWr">
                     <rect key="frame" x="10" y="216" width="20" height="22"/>
                     <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
@@ -72,6 +72,7 @@
                 <outlet property="issueBadge" destination="8Yr-oe-ZWr" id="1hW-OX-c8W"/>
                 <outlet property="issueNumber" destination="ffa-ud-S2G" id="XOL-O6-W0t"/>
                 <outlet property="issueTitle" destination="gDF-Uv-gPE" id="rkM-l9-FHb"/>
+                <outlet property="profilePicture" destination="TIo-KR-UoL" id="t2Q-Di-YHv"/>
             </connections>
             <point key="canvasLocation" x="211.59420289855075" y="194.86607142857142"/>
         </collectionReusableView>

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
@@ -126,6 +126,7 @@ class IssueDetailViewController: UIViewController {
         
         flowLayout.estimatedItemSize = CGSize(width: width, height: headerHeight)
         flowLayout.sectionInset = UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0)
+        flowLayout.headerReferenceSize = CGSize(width: view.frame.width, height: headerHeight)
         
         collectionView.collectionViewLayout = flowLayout
     }
@@ -159,17 +160,17 @@ extension IssueDetailViewController: UICollectionViewDataSource {
 }
 
 extension IssueDetailViewController: UICollectionViewDelegateFlowLayout {
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-
         let indexPath = IndexPath(row: 0, section: section)
+        
         if let headerView = self.collectionView(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader, at: indexPath) as? IssueDetailHeaderView {
-            headerView.layoutIfNeeded()
-            let height = headerView.systemLayoutSizeFitting(UIView.layoutFittingExpandedSize).height
 
-            return CGSize(width: self.view.frame.width, height: height)
+            let size = CGSize(width: collectionView.frame.width, height: UIView.layoutFittingExpandedSize.height)
+            
+            return headerView.systemLayoutSizeFitting(size, withHorizontalFittingPriority: .required, verticalFittingPriority: .fittingSizeLevel)
         }
-
+        
         return CGSize(width: self.view.frame.width, height: CGFloat(100))
     }
 

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
@@ -186,7 +186,8 @@ extension IssueDetailViewController: UICollectionViewDelegateFlowLayout {
         let indexPath = IndexPath(row: 0, section: section)
         if let headerView = self.collectionView(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader, at: indexPath) as? IssueDetailHeaderView {
             headerView.layoutIfNeeded()
-            let height = headerView.systemLayoutSizeFitting(UIView.layoutFittingExpandedSize).height
+            let height = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+
             return CGSize(width: self.view.frame.width, height: height)
         }
 

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
@@ -10,19 +10,12 @@ import UIKit
 
 class IssueDetailViewController: UIViewController {
     static let identifier = "IssueDetailViewController"
-    private var cellData = [
-        "레이블 전체 목록을 볼 수 있는게 어떨까요 전체 설명이 보여야 선택할 수 있으니까 마크다운 문법을 지원하고 HTML 형태로 보여줘야 할까요",
-        "긍정적인 기능이네요 댓글은 한 줄",
-        "아 힘드렁",
-        "Where does it come from? Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of \"de Finibus Bonorum et Malorum\" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, \"Lorem ipsum dolor sit amet..\", comes from a line in section 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from \"de Finibus Bonorum et Malorum\" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham."
-    ]
     
     @IBOutlet weak var collectionView: UICollectionView!
     private var addCommentView: AddCommentView?
-    private var issueDetailViewModel: IssueDetailViewModelProtocol?
+    private var issueDetailViewModel: IssueDetailViewModelProtocol
     private var currentIssueId: Int = -1
-    private var didFetchDetails: Bool = false
-    
+
     private var currentIndexPath: IndexPath? {
         let visibleRect = CGRect(origin: collectionView.contentOffset, size: collectionView.frame.size)
         let visiblePoint = CGPoint(x: visibleRect.midX, y: visibleRect.minY)
@@ -36,20 +29,21 @@ class IssueDetailViewController: UIViewController {
     init(issueDetailViewModel: IssueDetailViewModelProtocol) {
         self.issueDetailViewModel = issueDetailViewModel
         super.init(nibName: nil, bundle: nil)
-    }
-    
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        
+        self.issueDetailViewModel.didFetch = { [weak self] in
+            self?.collectionView.reloadData()
+        }
     }
     
     required init?(coder: NSCoder) {
+        issueDetailViewModel = IssueDetailViewModel(id: 1, issueProvider: nil, labelProvier: nil, milestoneProvider: nil)
         super.init(coder: coder)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationBarButtons()
-        configureIssueDetailViewModel()
+        issueDetailViewModel.needFetchDetails()
         navigationItem.title = "이슈 상세"
     }
     
@@ -65,12 +59,6 @@ class IssueDetailViewController: UIViewController {
     
     private func configureNavigationBarButtons() {
         configureEditButton()
-    }
-    
-    private func configureIssueDetailViewModel() {
-        issueDetailViewModel?.didFetch = { [weak self] in
-            self?.didFetchDetails = true
-        }
     }
     
     private func configureEditButton() {
@@ -122,7 +110,7 @@ class IssueDetailViewController: UIViewController {
         addCommentView.downButtonTapped = { [weak self] in
             guard let `self` = self,
                 let currentIndexPath = self.currentIndexPath,
-                currentIndexPath.item < self.cellData.count - 1
+                currentIndexPath.item < self.issueDetailViewModel.comments.count - 1
                 else { return }
             
             self.collectionView.scrollToItem(at: IndexPath(item: currentIndexPath.item + 1, section: 0), at: .top, animated: true)
@@ -147,29 +135,20 @@ class IssueDetailViewController: UIViewController {
 
 extension IssueDetailViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return cellData.count
+        return issueDetailViewModel.comments.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell: IssueDetailCellView = collectionView.dequeueCell(at: indexPath) else { return UICollectionViewCell() }
-        cell.configure(with: cellData[indexPath.row])
+        cell.configure(with: issueDetailViewModel.comments[indexPath.row])
         
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        guard let header: IssueDetailHeaderView = collectionView.dequeueHeader(at: indexPath) else { return UICollectionReusableView() }
         
-        guard let header: IssueDetailHeaderView = collectionView.dequeueHeader(at: indexPath),
-            let issueDetailViewModel = issueDetailViewModel
-            else { return UICollectionReusableView() }
-        
-        if didFetchDetails {
-            header.configure(with: issueDetailViewModel)
-        } else {
-            issueDetailViewModel.needFetchDetails()
-            header.configure(with: issueDetailViewModel)
-        }
-        
+        header.configure(with: issueDetailViewModel)
         return header
     }
     
@@ -186,7 +165,7 @@ extension IssueDetailViewController: UICollectionViewDelegateFlowLayout {
         let indexPath = IndexPath(row: 0, section: section)
         if let headerView = self.collectionView(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader, at: indexPath) as? IssueDetailHeaderView {
             headerView.layoutIfNeeded()
-            let height = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+            let height = headerView.systemLayoutSizeFitting(UIView.layoutFittingExpandedSize).height
 
             return CGSize(width: self.view.frame.width, height: height)
         }

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueEditScene/AddNewIssueViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueEditScene/AddNewIssueViewController.swift
@@ -9,19 +9,33 @@
 import UIKit
 import MarkdownView
 
+enum AddType: String {
+    case newIssue = "새 이슈"
+    case newComment = "댓글 추가"
+}
+
 class AddNewIssueViewController: UIViewController {
+    static let identifier = "AddNewIssueViewController"
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var segmentedControl: UISegmentedControl!
+    @IBOutlet weak var titleLabel: UILabel!
     private var commentTextView: UITextView = UITextView()
     private var markdownView: MarkdownView = MarkdownView()
+    var addType: AddType = .newIssue
     
     private let textViewPlaceholder = "코멘트는 여기에 작성하세요"
-    var doneButtonTapped: (() -> Void)?
+    var doneButtonTapped: ((String) -> Void)?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "새 이슈"
-        
+        switch addType {
+        case .newIssue:
+            titleLabel.isHidden = false
+            titleTextField.isHidden = false
+        case .newComment:
+            titleLabel.isHidden = true
+            titleTextField.isHidden = true
+        }
         configureKeyboardRelated()
         configureNavigationBar()
         configureCommentTextView()
@@ -83,18 +97,7 @@ class AddNewIssueViewController: UIViewController {
     }
     
     @IBAction func doneButtonTapped(_ sender: Any) {
-        /*
-         doneButtonTapped()
-         서버와 통신, POST 요청
-         응답이 오면 (OK status code, 서버 저장에 성공한 객체)
-         해당 객체를 decode 하여 프론트 collectionview의 datasource에도 추가
-         datasource는 이슈목록 리스트에 있으므로 doneButtonTapped를 주입시키든가 delegate protocol을 통해서 datasource를 건드릴 수 있도록 수정
-         
-         dismiss()
-         현재 VC를 dismiss한다.
-        */
-        
-        doneButtonTapped?()
+        doneButtonTapped?(commentTextView.text)
         self.dismiss(animated: true, completion: nil)
     }
     
@@ -158,4 +161,27 @@ extension AddNewIssueViewController: UITextViewDelegate {
             setTextViewPlaceholder()
         }
     }
+}
+
+extension AddNewIssueViewController {
+    
+    static let storyboardName = "EditIssue"
+    
+    static func present(at viewController: UIViewController,
+                        addType: AddType,
+                        onDismiss: ((String) -> Void)?) {
+        
+        let storyBoard = UIStoryboard(name: storyboardName, bundle: Bundle.main)
+        guard let container = storyBoard.instantiateInitialViewController() as? UINavigationController,
+            let vc = container.topViewController as? AddNewIssueViewController
+            else { return }
+        
+        vc.addType = addType
+        vc.title = addType.rawValue
+        vc.doneButtonTapped = onDismiss
+        
+        viewController.present(container, animated: true, completion: nil)
+        
+    }
+    
 }

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueEditScene/EditIssue.storyboard
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueEditScene/EditIssue.storyboard
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="y8U-UO-Qqa">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Add New Issue View Controller-->
+        <scene sceneID="xaJ-CG-com">
+            <objects>
+                <viewController storyboardIdentifier="AddNewIssueViewController" id="M35-c9-E8H" customClass="AddNewIssueViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Xo1-iA-LUn">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="4Wa-T2-4Np">
+                                <rect key="frame" x="10" y="158.5" width="394" height="106.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fTR-7F-740">
+                                        <rect key="frame" x="0.0" y="0.0" width="394" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" red="0.58823529409999997" green="0.58823529409999997" blue="0.58823529409999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WbQ-1C-VpD">
+                                        <rect key="frame" x="0.0" y="27.5" width="394" height="39.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Hp8-3G-REh">
+                                        <rect key="frame" x="0.0" y="74" width="394" height="33.5"/>
+                                        <segments>
+                                            <segment title="마크다운"/>
+                                            <segment title="미리보기"/>
+                                        </segments>
+                                        <connections>
+                                            <action selector="segmentDidChange:" destination="M35-c9-E8H" eventType="valueChanged" id="oTx-gk-Te1"/>
+                                        </connections>
+                                    </segmentedControl>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="Hp8-3G-REh" firstAttribute="height" secondItem="4Wa-T2-4Np" secondAttribute="height" multiplier="0.04" constant="27.920000000000002" id="46l-8s-OSs"/>
+                                    <constraint firstItem="WbQ-1C-VpD" firstAttribute="height" secondItem="4Wa-T2-4Np" secondAttribute="height" multiplier="0.05" constant="34.399999999999999" id="eaj-FU-wfX"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="4Wa-T2-4Np" firstAttribute="top" secondItem="Jyn-Am-b0I" secondAttribute="top" constant="10" id="2zw-ll-OL4"/>
+                            <constraint firstItem="4Wa-T2-4Np" firstAttribute="leading" secondItem="Jyn-Am-b0I" secondAttribute="leading" constant="10" id="W0a-yT-MJo"/>
+                            <constraint firstItem="Jyn-Am-b0I" firstAttribute="trailing" secondItem="4Wa-T2-4Np" secondAttribute="trailing" constant="10" id="k1b-ht-znZ"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Jyn-Am-b0I"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="FSZ-nB-s8A">
+                        <barButtonItem key="leftBarButtonItem" style="done" id="oit-GN-QoT">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="gb4-Tc-aB5">
+                                <rect key="frame" x="20" y="7" width="92" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Cancel"/>
+                                <connections>
+                                    <action selector="cancelButtonTapped:" destination="M35-c9-E8H" eventType="touchUpInside" id="m7n-Sp-ebY"/>
+                                </connections>
+                            </button>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" id="150-PN-DNy">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="4IY-l3-prl">
+                                <rect key="frame" x="302" y="7" width="92" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Done"/>
+                                <connections>
+                                    <action selector="doneButtonTapped:" destination="M35-c9-E8H" eventType="touchUpInside" id="qSj-L3-c2o"/>
+                                </connections>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="segmentedControl" destination="Hp8-3G-REh" id="cMI-ph-19y"/>
+                        <outlet property="titleLabel" destination="fTR-7F-740" id="1xx-bF-yh7"/>
+                        <outlet property="titleTextField" destination="WbQ-1C-VpD" id="5uA-QI-WCU"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="TIE-yf-wzQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3683" y="-556"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="VO4-Ll-gYt">
+            <objects>
+                <navigationController storyboardIdentifier="AddIssueNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="y8U-UO-Qqa" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="pE2-l5-t6I">
+                        <rect key="frame" x="0.0" y="44" width="414" height="104.5"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="M35-c9-E8H" kind="relationship" relationship="rootViewController" destinationCreationSelector="addIssueSeguePerformed:" id="4wM-hd-bac"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0ml-dF-Rhd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2807" y="-556"/>
+        </scene>
+    </scenes>
+</document>

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueListScene/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueListScene/IssueListViewController.swift
@@ -40,7 +40,7 @@ class IssueListViewController: UIViewController {
         issueListViewModel?.needFetchItems()
         navigationController?.isToolbarHidden = true
     }
-
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationItem.largeTitleDisplayMode = .automatic
@@ -67,6 +67,11 @@ class IssueListViewController: UIViewController {
         layout.estimatedItemSize = CGSize(width: self.view.bounds.width, height: cellHeight)
         layout.minimumLineSpacing = 1
         collectionView.setCollectionViewLayout(layout, animated: false)
+    }
+    
+    @IBAction func addIssueButtonTapped(_ sender: Any) {
+        // TODO : add issue
+        AddNewIssueViewController.present(at: self, addType: .newIssue, onDismiss: nil)
     }
     
 }
@@ -156,11 +161,6 @@ extension IssueListViewController {
         self.navigationController?.pushViewController(issueDetailVC, animated: true)
     }
     
-    @IBSegueAction func addIssueSeguePerformed(_ coder: NSCoder) -> AddNewIssueViewController? {
-        let addIssueViewController = AddNewIssueViewController(coder: coder)
-        // addIssueVC의 doneButtonTapped 주입
-        return addIssueViewController
-    }
     
 }
 
@@ -168,7 +168,7 @@ extension IssueListViewController {
 extension IssueListViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cellView: IssueCellView = collectionView.dequeueCell(at: indexPath),
-              let cellViewModel = issueListViewModel?.cellForItemAt(path: indexPath) else { return UICollectionViewCell() }
+            let cellViewModel = issueListViewModel?.cellForItemAt(path: indexPath) else { return UICollectionViewCell() }
         cellView.configure(issueItemViewModel: cellViewModel)
         cellView.showCheckBox(show: viewingMode == .edit, animation: false)
         return cellView

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/ViewModel/IssueDetailViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/ViewModel/IssueDetailViewModel.swift
@@ -19,21 +19,20 @@ protocol IssueDetailViewModelProtocol {
     var labels: [LabelItemViewModel] { get }
     var assignees: [UserViewModel] { get }
     func needFetchDetails()
+    func addComment(content: String)
 }
 
 struct CommentViewModel {
-    let id: Int
     let content: String
     let createAt: String
     let userName: String
     let imageURL: String?
     
     init(comment: Comment) {
-        id = comment.id
         content = comment.content
         createAt = comment.createAt
-        userName = comment.user.name
-        imageURL = comment.user.imageUrl
+        userName = comment.author.name
+        imageURL = comment.author.imageUrl
     }
 }
 
@@ -76,7 +75,6 @@ class IssueDetailViewModel: IssueDetailViewModelProtocol {
     }
     
     func needFetchDetails() {
-        print("needFetchDetails()")
         issueProvider?.getIssue(at: issueNumber) { [weak self] (issue) in
             guard let `self` = self,
                 let currentIssue = issue
@@ -105,4 +103,13 @@ class IssueDetailViewModel: IssueDetailViewModelProtocol {
             self.didFetch?()
         }
     }
+    
+    func addComment(content: String) {
+        issueProvider?.addComment(issueNumber: self.issueNumber, content: content) { [weak self] (response) in
+            guard let `self` = self, response else { return }
+            self.comments.append(CommentViewModel(comment: Comment(content: content, user: User(id: 1))))
+            self.didFetch?()
+        }
+    }
+    
 }

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/ViewModel/IssueDetailViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/ViewModel/IssueDetailViewModel.swift
@@ -76,6 +76,7 @@ class IssueDetailViewModel: IssueDetailViewModelProtocol {
     }
     
     func needFetchDetails() {
+        print("needFetchDetails()")
         issueProvider?.getIssue(at: issueNumber) { [weak self] (issue) in
             guard let `self` = self,
                 let currentIssue = issue

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/ViewModel/IssueDetailViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/ViewModel/IssueDetailViewModel.swift
@@ -11,36 +11,72 @@ import Foundation
 protocol IssueDetailViewModelProtocol {
     var issueNumber: Int { get }
     var title: String { get }
-    var description: String { get }
     var author: String { get }
     var isOpened: Bool { get }
     var didFetch: (() -> Void)? { get set }
+    var milestone: MilestoneItemViewModel? { get }
+    var comments: [CommentViewModel] { get }
+    var labels: [LabelItemViewModel] { get }
+    var assignees: [UserViewModel] { get }
     func needFetchDetails()
+}
+
+struct CommentViewModel {
+    let id: Int
+    let content: String
+    let createAt: String
+    let userName: String
+    let imageURL: String?
+    
+    init(comment: Comment) {
+        id = comment.id
+        content = comment.content
+        createAt = comment.createAt
+        userName = comment.user.name
+        imageURL = comment.user.imageUrl
+    }
+}
+
+protocol UserViewModelProtocol {
+    var userName: String { get set }
+    var imageURL: String? { get set }
+}
+
+struct UserViewModel {
+    var userName: String
+    var imageURL: String?
+    
+    init(user: User) {
+        userName = user.name
+        imageURL = user.imageUrl
+    }
 }
 
 class IssueDetailViewModel: IssueDetailViewModelProtocol {
     
     var issueNumber: Int = 0
     var title: String = ""
-    var description: String = ""
     var author: String = ""
     var didFetch: (() -> Void)?
     var isOpened: Bool = false
+    var milestone: MilestoneItemViewModel?
+    var comments: [CommentViewModel] = [CommentViewModel]()
+    var labels: [LabelItemViewModel] = [LabelItemViewModel]()
+    var assignees: [UserViewModel] = [UserViewModel]()
+    
     private weak var issueProvider: IssueProvidable?
+    private weak var labelProvier: LabelProvidable?
+    private weak var milestoneProvider: MilestoneProvidable?
     
-    init(issueProvider: IssueProvidable) {
-        self.issueProvider = issueProvider
-    }
-    
-    init(id: Int, title: String, description: String, issueProvider: IssueProvidable?) {
-        self.issueProvider = issueProvider
+    init(id: Int, issueProvider: IssueProvidable?, labelProvier: LabelProvidable?, milestoneProvider: MilestoneProvidable?) {
         self.issueNumber = id
-        self.title = title
-        self.description = description
+        self.issueProvider = issueProvider
+        self.labelProvier = labelProvier
+        self.milestoneProvider = milestoneProvider
     }
     
     func needFetchDetails() {
-        issueProvider?.getIssue(at: issueNumber, completion: { [weak self] (issue) in
+        issueProvider?.getIssue(at: issueNumber) { [weak self] (issue) in
             guard let `self` = self,
                 let currentIssue = issue
                 else { return }
@@ -48,9 +84,24 @@ class IssueDetailViewModel: IssueDetailViewModelProtocol {
             self.issueNumber = currentIssue.id
             self.title = currentIssue.title
             self.isOpened = currentIssue.isOpened
-            self.description = currentIssue.description
             self.author = currentIssue.author
+            
+            self.comments = currentIssue.comments.map { CommentViewModel(comment: $0) }
+            
+            self.labelProvier?.getLabels(of: currentIssue.labels) { (labels) in
+                self.labels = labels.map { LabelItemViewModel(label: $0)}
+            }
+            
+            if let milestoneId = currentIssue.milestone {
+                self.milestoneProvider?.getMilestone(at: milestoneId) { (milestone) in
+                    guard let milestone = milestone else { return }
+                    self.milestone = MilestoneItemViewModel(milestone: milestone, from: .fromServer)
+                }
+            }
+            
+            self.assignees = currentIssue.assignees.map { UserViewModel(user: $0)}
+            
             self.didFetch?()
-        })
+        }
     }
 }

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/ViewModel/IssueListViewModel.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/ViewModel/IssueListViewModel.swift
@@ -89,8 +89,8 @@ class IssueListViewModel: IssueListViewModelProtocol {
     func createIssueDetailViewModel(path: IndexPath) -> IssueDetailViewModel? {
         let cellViewModel = issues[path.row]
         return IssueDetailViewModel(id: cellViewModel.id,
-                                    title: cellViewModel.title,
-                                    description: cellViewModel.description,
-                                    issueProvider: issueProvider)
+                                    issueProvider: issueProvider,
+                                    labelProvier: labelProvider,
+                                    milestoneProvider: milestoneProvider)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/04.Models/Issue.swift
+++ b/iOS/IssueTracker/IssueTracker/04.Models/Issue.swift
@@ -246,28 +246,24 @@ struct User {
 
 // TODO: Comment DataModel? <- 그냥 이슈가 들고있는게 좋나?
 struct Comment {
-    let id: Int
     let content: String
     let createAt: String
-    let user: User
+    let author: User
     
-    init(id: Int) {
-        self.id = id
-        self.content = ""
+    init(content: String, user: User) {
+        self.content = content
         self.createAt = ""
-        self.user = User(id: id)
+        self.author = user
     }
     
     init?(json: [String: Any]) {
-        guard let id = json["id"] as? Int,
-            let content = json["content"] as? String,
+        guard let content = json["content"] as? String,
             let createAt = json["createAt"] as? String,
             let userObject = json["user"] as? [String: Any],
             let user = User(json: userObject)
             else { return nil }
-        self.id = id
         self.content = content
         self.createAt = createAt
-        self.user = user
+        self.author = user
     }
 }

--- a/iOS/IssueTracker/IssueTracker/04.Models/Issue.swift
+++ b/iOS/IssueTracker/IssueTracker/04.Models/Issue.swift
@@ -56,7 +56,7 @@ struct Issue {
         self.isOpened = true
         self.comments = []
     }
-   
+    
     mutating func addLabel(id: Int) {
         if labels.contains(where: {$0 == id}) { return }
         labels.append(id)
@@ -124,14 +124,14 @@ extension Issue {
     
     static func fetchResponse(jsonObject: [String: Any]?) -> Issue? {
         guard let jsonObject = jsonObject,
-              let id = jsonObject["id"] as? Int,
-              let title = jsonObject["title"] as? String,
-              let isOpened = jsonObject["isOpened"] as? Bool,
-              let createdAt = jsonObject["createAt"] as? String,
-              let updatedAt = jsonObject["updateAt"] as? String,
-              let labelObjects = jsonObject["labels"] as? [[String: Any]],
-              let assigneeObjects = jsonObject["assignees"] as? [[String: Any]]
-        else { return nil }
+            let id = jsonObject["id"] as? Int,
+            let title = jsonObject["title"] as? String,
+            let isOpened = jsonObject["isOpened"] as? Bool,
+            let createdAt = jsonObject["createAt"] as? String,
+            let updatedAt = jsonObject["updateAt"] as? String,
+            let labelObjects = jsonObject["labels"] as? [[String: Any]],
+            let assigneeObjects = jsonObject["assignees"] as? [[String: Any]]
+            else { return nil }
         let labels = labelObjects.compactMap { $0["id"] as? Int }
         let assignees = assigneeObjects.compactMap { User(json: $0) }
         let description = ""
@@ -165,32 +165,33 @@ extension Issue {
     
     static func addResponse(jsonObject: [String: Any]?) -> Issue? {
         guard let jsonObject = jsonObject,
-              let id = jsonObject["id"] as? Int,
-              let title = jsonObject["title"] as? String,
-              let isOpened = jsonObject["isOpened"] as? Bool,
-              let createAt = jsonObject["createAt"] as? String,
-              let updateAt = jsonObject["updateAt"] as? String,
-              let authorId = jsonObject["authorId"] as? Int
-        else { return nil }
+            let id = jsonObject["id"] as? Int,
+            let title = jsonObject["title"] as? String,
+            let isOpened = jsonObject["isOpened"] as? Bool,
+            let createAt = jsonObject["createAt"] as? String,
+            let updateAt = jsonObject["updateAt"] as? String,
+            let authorId = jsonObject["authorId"] as? Int
+            else { return nil }
         let description = (jsonObject["description"] as? String) ?? ""
         let milestoneId = jsonObject["milestoneId"] as? Int
         
         return Issue(id: id, title: title, description: description, author: String(authorId), isOpened: isOpened, createdAt: createAt, updatedAt: updateAt, milestone: milestoneId)
     }
-
+    
     // from getIssue API
     static func getResponse(jsonObject: [String: Any]?) -> Issue? {
         guard let jsonObject = jsonObject,
-              let id = jsonObject["id"] as? Int,
-              let title = jsonObject["title"] as? String,
-              let isOpened = jsonObject["isOpened"] as? Bool,
-              let createAt = jsonObject["createAt"] as? String,
-              let updateAt = jsonObject["updateAt"] as? String,
-              let author = jsonObject["author"] as? String,
-              let labelObjects = jsonObject["labels"] as? [[String: Any]],
-              let assigneeObjects = jsonObject["assignees"] as? [[String: Any]],
-              let commentObjects = jsonObject["comments"] as? [[String: Any]]
-        else { return nil }
+            let id = jsonObject["id"] as? Int,
+            let title = jsonObject["title"] as? String,
+            let isOpened = jsonObject["isOpened"] as? Bool,
+            let createAt = jsonObject["createAt"] as? String,
+            let updateAt = jsonObject["updateAt"] as? String,
+            let authorObject = jsonObject["author"] as? [String: Any],
+            let author = authorObject["userName"] as? String,
+            let labelObjects = jsonObject["labels"] as? [[String: Any]],
+            let assigneeObjects = jsonObject["assignees"] as? [[String: Any]],
+            let commentObjects = jsonObject["comments"] as? [[String: Any]]
+            else { return nil }
         let description = (jsonObject["description"] as? String) ?? ""
         let milestoneId = (jsonObject["milestone"] as? [String: Any])?["id"] as? Int
         let labels = labelObjects.compactMap { $0["id"] as? Int }
@@ -259,11 +260,11 @@ struct Comment {
     
     init?(json: [String: Any]) {
         guard let id = json["id"] as? Int,
-              let content = json["content"] as? String,
-              let createAt = json["createAt"] as? String,
-              let userObject = json["user"] as? [String: Any],
-              let user = User(json: userObject)
-        else { return nil }
+            let content = json["content"] as? String,
+            let createAt = json["createAt"] as? String,
+            let userObject = json["user"] as? [String: Any],
+            let user = User(json: userObject)
+            else { return nil }
         self.id = id
         self.content = content
         self.createAt = createAt

--- a/iOS/IssueTracker/IssueTracker/04.Models/IssueProvider.swift
+++ b/iOS/IssueTracker/IssueTracker/04.Models/IssueProvider.swift
@@ -31,7 +31,7 @@ class IssueProvider: IssueProvidable {
     // TODO: 같은 Fetch 요청이 여러번 들어왔을 겨우 completion을 배열에 넣어두었다 한 패칭에 Completion을 모두 처리해주는 방식으로!
     private var onFetching: Bool = false
     private(set) var issues: [Issue] = [ // labels 9 ~ 17 milestone 19, 22, 23, 24, 25, 28, 36
-        Issue(id: 1, title: "이슈[1]", description: "ABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGH", labels: [9], milestone: 19, author: "JK", isOpened: true),
+        Issue(id: 1, title: "BCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGH", description: "ABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGHABCDEFGH", labels: [9], milestone: 19, author: "JK", isOpened: true),
         Issue(id: 2, title: "이슈[2]", description: "ABCDEFGH", labels: [10], milestone: 22, author: "JK", isOpened: true),
         Issue(id: 3, title: "이슈[3]", description: "ABCDEFGH", labels: [11], milestone: 23, author: "JK", isOpened: true),
         Issue(id: 4, title: "이슈[4]", description: "ABCDEFGH", labels: [12], milestone: 24, author: "JK", isOpened: true),
@@ -55,19 +55,19 @@ class IssueProvider: IssueProvidable {
     func fetchIssues(completion: @escaping ([Issue]?) -> Void) {
         onFetching = true
 
-        dataLoader?.request(IssueService.fetchAll(true), callBackQueue: .main, completion: { (response) in
-            switch response {
-            case .failure:
-                completion(nil)
-            case .success(let response):
-                if let issues = Issue.fetchResponse(jsonArr: response.mapJsonArr()) {
-                    completion(issues)
-                    self.issues = issues
-                }
-            }
-        })
+//        dataLoader?.request(IssueService.fetchAll(true), callBackQueue: .main, completion: { (response) in
+//            switch response {
+//            case .failure:
+//                completion(nil)
+//            case .success(let response):
+//                if let issues = Issue.fetchResponse(jsonArr: response.mapJsonArr()) {
+//                    completion(issues)
+//                    self.issues = issues
+//                }
+//            }
+//        })
 
-//        completion(issues)
+        completion(issues)
         onFetching = false
     }
     

--- a/iOS/IssueTracker/IssueTracker/04.Models/IssueProvider.swift
+++ b/iOS/IssueTracker/IssueTracker/04.Models/IssueProvider.swift
@@ -55,19 +55,19 @@ class IssueProvider: IssueProvidable {
     func fetchIssues(completion: @escaping ([Issue]?) -> Void) {
         onFetching = true
 
-//        dataLoader?.request(IssueService.fetchAll(true), callBackQueue: .main, completion: { (response) in
-//            switch response {
-//            case .failure:
-//                completion(nil)
-//            case .success(let response):
-//                if let issues = Issue.fetchResponse(jsonArr: response.mapJsonArr()) {
-//                    completion(issues)
-//                    self.issues = issues
-//                }
-//            }
-//        })
+        dataLoader?.request(IssueService.fetchAll(true), callBackQueue: .main, completion: { (response) in
+            switch response {
+            case .failure:
+                completion(nil)
+            case .success(let response):
+                if let issues = Issue.fetchResponse(jsonArr: response.mapJsonArr()) {
+                    completion(issues)
+                    self.issues = issues
+                }
+            }
+        })
 
-        completion(issues)
+        // completion(issues)
         onFetching = false
     }
     

--- a/iOS/IssueTracker/IssueTracker/04.Models/IssueProvider.swift
+++ b/iOS/IssueTracker/IssueTracker/04.Models/IssueProvider.swift
@@ -22,6 +22,7 @@ protocol IssueProvidable: AnyObject {
     func deleteMilestone(at id: Int, completion: @escaping (Issue?) -> Void)
     func addAsignee(at id: Int, userId: Int, completion: @escaping (Issue?) -> Void)
     func deleteAsignee(at id: Int, userId: Int, completion: @escaping (Issue?) -> Void)
+    func addComment(issueNumber: Int, content: String, completion: @escaping (Bool) -> Void)
 }
 
 class IssueProvider: IssueProvidable {
@@ -69,6 +70,20 @@ class IssueProvider: IssueProvidable {
 
         // completion(issues)
         onFetching = false
+    }
+    
+    /*
+     Response :
+     */
+    func addComment(issueNumber: Int, content: String, completion: @escaping (Bool) -> Void) {
+        dataLoader?.request(CommentService.addComment(1, issueNumber, content), callBackQueue: .main, completion: { (response) in
+            switch response {
+            case .failure:
+                completion(false)
+            case .success:
+                completion(true)
+            }
+        })
     }
     
     /*

--- a/iOS/IssueTracker/IssueTracker/07.Supports/Info.plist
+++ b/iOS/IssueTracker/IssueTracker/07.Supports/Info.plist
@@ -2,11 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSAppTransportSecurity</key>
-    <dict>
-        <key>NSAllowsArbitraryLoads</key>
-        <true/>
-    </dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -25,6 +20,11 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -55,8 +55,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/iOS/IssueTracker/IssueTracker/08.Endpoints/CommentService.swift
+++ b/iOS/IssueTracker/IssueTracker/08.Endpoints/CommentService.swift
@@ -11,17 +11,17 @@ import NetworkFramework
 
 enum CommentService {
     
-    // addComment ( issueId, comment )
+    // addComment ( userId, issueId, comment )
     // [POST] /api/comment
-    case addComment( Int, String)
+    case addComment(Int, Int, String)
     
     // editComment ( issueId, comment )
     // [PATCH] /api/comment/:id
-    case editComment( Int, String)
+    case editComment(Int, String)
     
     // deleteComment ( issueId)
     // [DELETE] /api/comment/:id
-    case deleteComment( Int)
+    case deleteComment(Int)
     
 }
 
@@ -55,9 +55,10 @@ extension CommentService: IssueTrackerService {
     
     var task: Task {
         switch self {
-        case .addComment(let id, let comment):
+        case .addComment(let userId, let issueId, let comment):
             var jsonObject = [String: Any]()
-            jsonObject["issueID"] = id
+            jsonObject["userId"] = userId
+            jsonObject["issueId"] = issueId
             jsonObject["content"] = comment
             return .requestJsonObject(jsonObject)
         case .editComment(let id, let comment):


### PR DESCRIPTION
### Issue Number

### 변경사항
이슈목록화면 <-> 이슈상세화면 데이터 연결 (id값을 넘겨주고 해당 값을 이슈 상세화면에서 HTTP GET요청을 통해 받아오도록 구현)
이슈상세화면 datasource 실제 서버의 데이터로 변경
이슈상세화면 <-> 하단메뉴화면 delegate pattern으로 연결
하단메뉴화면에서 댓글추가버튼을 누를 시, 댓글추가(새 이슈와 동일한 화면)화면이 modally present 되는데 이 때 present하는 주체 VC는 이슈상세화면
새 이슈, 댓글추가에 재사용되는 ViewController의 다른 UI 틀을 newComment / newIssue로 분기를 나누어 처리
새 이슈, 댓글추가에 재사용되는 VC는 storyboard를 분리
 
### 새로운 기능
이슈상세화면에서 실제 데이터 활용
댓글추가기능

TODO
self-sizing header -> auto layout error 처리하기
새 이슈 등록화면에서 Done 버튼 누를 시 실제 서버에 이슈 추가하고 이슈목록화면 Reload data

### 작업 유형
- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
