### PR TITLE
bottomSheet 위로 스크롤 시 blur 처리 구현

### DIFF
--- a/iOS/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/Base.lproj/Main.storyboard
@@ -149,7 +149,7 @@
                     <tabBarItem key="tabBarItem" title="이슈" image="1.circle.fill" catalog="system" id="A1f-zK-Nd4"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="LqH-iR-KEA">
-                        <rect key="frame" x="0.0" y="44" width="414" height="104.5"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/BottomSheetViews/BottomSheetView.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/BottomSheetViews/BottomSheetView.swift
@@ -13,6 +13,7 @@ protocol BottomSheetViewDelegate: AnyObject {
     func upButtonTapped()
     func downButtonTapped()
     func categoryHeaderTapped(type: DetailSelectionType)
+    func heightChanged(with: CGFloat)
 }
 
 class BottomSheetView: UIView {
@@ -52,6 +53,10 @@ class BottomSheetView: UIView {
         self.addGestureRecognizer(gesture)
     }
     
+    override func layoutSubviews() {
+        delegate?.heightChanged(with: self.frame.minY)
+    }
+    
 }
 
 // MARK: - Action
@@ -77,7 +82,7 @@ extension BottomSheetView {
         let velocity = recognizer.velocity(in: self)
         let y = self.frame.minY
         
-        if ( y + translation.y >= fullView) && (y + translation.y <= partialView ) {
+        if (y + translation.y >= fullView) && (y + translation.y <= partialView ) {
             self.frame = CGRect(x: 0, y: y + translation.y, width: self.frame.width, height: self.frame.height)
             recognizer.setTranslation(CGPoint.zero, in: self)
         }

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
@@ -42,7 +42,8 @@ class IssueDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupBlurView()
+        setupNavBarBlur()
+        setupContentBlur()
         configureEditButton()
         issueDetailViewModel.needFetchDetails()
         configureCollectionView()
@@ -50,22 +51,40 @@ class IssueDetailViewController: UIViewController {
         navigationItem.title = "이슈 상세"
     }
     
-    let blurredEffectView: UIVisualEffectView = {
+    let contentBlurView: UIVisualEffectView = {
         let blurEffect = UIBlurEffect(style: .dark)
         let blurredEffectView = UIVisualEffectView(effect: blurEffect)
         blurredEffectView.translatesAutoresizingMaskIntoConstraints = false
         return blurredEffectView
     }()
     
-    func setupBlurView() {
-        blurredEffectView.alpha = 0
-        self.view.addSubview(blurredEffectView)
+    let navBarBlurView: UIVisualEffectView = {
+        let blurEffect = UIBlurEffect(style: .dark)
+        let blurredEffectView = UIVisualEffectView(effect: blurEffect)
+        blurredEffectView.translatesAutoresizingMaskIntoConstraints = false
+        return blurredEffectView
+    }()
+    
+    func setupNavBarBlur() {
+        navBarBlurView.alpha = 0
+        self.navigationController?.navigationBar.addSubview(navBarBlurView)
+        NSLayoutConstraint.activate([
+            navBarBlurView.topAnchor.constraint(equalTo: (self.navigationController?.navigationBar.topAnchor)!),
+            navBarBlurView.leadingAnchor.constraint(equalTo: (self.navigationController?.navigationBar.leadingAnchor)!),
+            navBarBlurView.trailingAnchor.constraint(equalTo: (self.navigationController?.navigationBar.trailingAnchor)!),
+            navBarBlurView.bottomAnchor.constraint(equalTo: (self.navigationController?.navigationBar.bottomAnchor)!)
+        ])
+    }
+    
+    func setupContentBlur() {
+        navBarBlurView.alpha = 0
+        self.view.addSubview(contentBlurView)
         
         NSLayoutConstraint.activate([
-            blurredEffectView.topAnchor.constraint(equalTo: self.view.topAnchor),
-            blurredEffectView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            blurredEffectView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            blurredEffectView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+            contentBlurView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            contentBlurView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            contentBlurView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            contentBlurView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
         ])
     }
     
@@ -77,12 +96,12 @@ class IssueDetailViewController: UIViewController {
         let width  = UIScreen.main.bounds.width
         bottomSheetView?.frame = CGRect(x: 0, y: height * 0.9, width: width, height: height)
     }
-
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.tabBarController?.tabBar.isHidden = false
     }
-
+    
     private func configureEditButton() {
         let editButton = UIBarButtonItem(title: "Edit", style: .done, target: self, action: #selector(editButtonTapped))
         self.navigationItem.rightBarButtonItem = editButton
@@ -181,7 +200,8 @@ extension IssueDetailViewController: BottomSheetViewDelegate {
     func heightChanged(with newHeight: CGFloat) {
         let newAlpha = newHeight / 1000
         DispatchQueue.main.async { [weak self] in
-            self?.blurredEffectView.alpha = (newAlpha - 0.5) * -1
+            self?.contentBlurView.alpha = (newAlpha - 0.5) * -1
+            self?.navBarBlurView.alpha = (newAlpha - 0.5) * -1
         }
     }
     

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
@@ -42,11 +42,31 @@ class IssueDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupBlurView()
         configureEditButton()
         issueDetailViewModel.needFetchDetails()
         configureCollectionView()
         configureBottomSheetView()
         navigationItem.title = "이슈 상세"
+    }
+    
+    let blurredEffectView: UIVisualEffectView = {
+        let blurEffect = UIBlurEffect(style: .dark)
+        let blurredEffectView = UIVisualEffectView(effect: blurEffect)
+        blurredEffectView.translatesAutoresizingMaskIntoConstraints = false
+        return blurredEffectView
+    }()
+    
+    func setupBlurView() {
+        blurredEffectView.alpha = 0
+        self.view.addSubview(blurredEffectView)
+        
+        NSLayoutConstraint.activate([
+            blurredEffectView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            blurredEffectView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            blurredEffectView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            blurredEffectView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+        ])
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -57,7 +77,7 @@ class IssueDetailViewController: UIViewController {
         let width  = UIScreen.main.bounds.width
         bottomSheetView?.frame = CGRect(x: 0, y: height * 0.9, width: width, height: height)
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.tabBarController?.tabBar.isHidden = false
@@ -158,6 +178,12 @@ extension IssueDetailViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - BottomSheetViewDelegate Implementatioin
 
 extension IssueDetailViewController: BottomSheetViewDelegate {
+    func heightChanged(with newHeight: CGFloat) {
+        let newAlpha = newHeight / 1000
+        DispatchQueue.main.async { [weak self] in
+            self?.blurredEffectView.alpha = (newAlpha - 0.5) * -1
+        }
+    }
     
     func categoryHeaderTapped(type: DetailSelectionType) {
         let maximumSelection = type == .milestone ? 1 : 0

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
@@ -15,6 +15,20 @@ class IssueDetailViewController: UIViewController {
     private var bottomSheetView: BottomSheetView?
     private var issueDetailViewModel: IssueDetailViewModelProtocol
     
+    let contentBlurView: UIVisualEffectView = {
+        let blurEffect = UIBlurEffect(style: .dark)
+        let blurredEffectView = UIVisualEffectView(effect: blurEffect)
+        blurredEffectView.translatesAutoresizingMaskIntoConstraints = false
+        return blurredEffectView
+    }()
+    
+    let navBarBlurView: UIVisualEffectView = {
+        let blurEffect = UIBlurEffect(style: .dark)
+        let blurredEffectView = UIVisualEffectView(effect: blurEffect)
+        blurredEffectView.translatesAutoresizingMaskIntoConstraints = false
+        return blurredEffectView
+    }()
+    
     private var currentIndexPath: IndexPath? {
         let visibleRect = CGRect(origin: collectionView.contentOffset, size: collectionView.frame.size)
         let visiblePoint = CGPoint(x: visibleRect.midX, y: visibleRect.minY)
@@ -51,43 +65,6 @@ class IssueDetailViewController: UIViewController {
         navigationItem.title = "이슈 상세"
     }
     
-    let contentBlurView: UIVisualEffectView = {
-        let blurEffect = UIBlurEffect(style: .dark)
-        let blurredEffectView = UIVisualEffectView(effect: blurEffect)
-        blurredEffectView.translatesAutoresizingMaskIntoConstraints = false
-        return blurredEffectView
-    }()
-    
-    let navBarBlurView: UIVisualEffectView = {
-        let blurEffect = UIBlurEffect(style: .dark)
-        let blurredEffectView = UIVisualEffectView(effect: blurEffect)
-        blurredEffectView.translatesAutoresizingMaskIntoConstraints = false
-        return blurredEffectView
-    }()
-    
-    func setupNavBarBlur() {
-        navBarBlurView.alpha = 0
-        self.navigationController?.navigationBar.addSubview(navBarBlurView)
-        NSLayoutConstraint.activate([
-            navBarBlurView.topAnchor.constraint(equalTo: (self.navigationController?.navigationBar.topAnchor)!),
-            navBarBlurView.leadingAnchor.constraint(equalTo: (self.navigationController?.navigationBar.leadingAnchor)!),
-            navBarBlurView.trailingAnchor.constraint(equalTo: (self.navigationController?.navigationBar.trailingAnchor)!),
-            navBarBlurView.bottomAnchor.constraint(equalTo: (self.navigationController?.navigationBar.bottomAnchor)!)
-        ])
-    }
-    
-    func setupContentBlur() {
-        navBarBlurView.alpha = 0
-        self.view.addSubview(contentBlurView)
-        
-        NSLayoutConstraint.activate([
-            contentBlurView.topAnchor.constraint(equalTo: self.view.topAnchor),
-            contentBlurView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            contentBlurView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            contentBlurView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
-        ])
-    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationItem.largeTitleDisplayMode = .never
@@ -100,6 +77,31 @@ class IssueDetailViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.tabBarController?.tabBar.isHidden = false
+    }
+    
+    private func setupNavBarBlur() {
+        navBarBlurView.alpha = 0
+        let navBarHeight = navigationController?.navigationBar.frame.height ?? 50
+        self.navigationController?.navigationBar.addSubview(navBarBlurView)
+        
+        NSLayoutConstraint.activate([
+            navBarBlurView.topAnchor.constraint(equalTo: (self.navigationController?.navigationBar.topAnchor)!, constant: -1 * navBarHeight),
+            navBarBlurView.leadingAnchor.constraint(equalTo: (self.navigationController?.navigationBar.leadingAnchor)!),
+            navBarBlurView.trailingAnchor.constraint(equalTo: (self.navigationController?.navigationBar.trailingAnchor)!),
+            navBarBlurView.bottomAnchor.constraint(equalTo: (self.navigationController?.navigationBar.bottomAnchor)!)
+        ])
+    }
+    
+    private func setupContentBlur() {
+        navBarBlurView.alpha = 0
+        self.view.addSubview(contentBlurView)
+        
+        NSLayoutConstraint.activate([
+            contentBlurView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            contentBlurView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            contentBlurView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            contentBlurView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+        ])
     }
     
     private func configureEditButton() {

--- a/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/01.IssueScene/IssueDetailScene/IssueDetailViewController.swift
@@ -53,6 +53,9 @@ class IssueDetailViewController: UIViewController {
         super.viewWillAppear(animated)
         self.navigationItem.largeTitleDisplayMode = .never
         self.tabBarController?.tabBar.isHidden = true
+        let height = UIScreen.main.bounds.height
+        let width  = UIScreen.main.bounds.width
+        bottomSheetView?.frame = CGRect(x: 0, y: height * 0.9, width: width, height: height)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -89,9 +92,6 @@ class IssueDetailViewController: UIViewController {
         guard let bottomSheetView = BottomSheetView.createView() else { return }
         bottomSheetView.configure(issueDetailViewModel: issueDetailViewModel)
         bottomSheetView.delegate = self
-        let height = UIScreen.main.bounds.height
-        let width  = UIScreen.main.bounds.width
-        bottomSheetView.frame = CGRect(x: 0, y: height * 0.9, width: width, height: height)
         
         self.bottomSheetView = bottomSheetView
         self.view.addSubview(bottomSheetView)


### PR DESCRIPTION
### Issue Number

### 변경사항
blur 처리하는 로직 구현
UIBlurEffectView는 뷰 상에서 자신보다 아래 있는 (부모) 뷰에 대해 blur 처리를 하는데 navigation bar, content가 hierarchy가 달라서 따로 처리해주었음. (contentBlurView / navBarBlurView)
safe area 보다 위에영역까지 동일한 효과를 주기 위해 constraint를 topAnchor에 음수값을 주었음.
더 효율적인 방법이 있을 지 고려해볼 것

### 새로운 기능
bottomSheet을 위로 올릴 때 blur 처리, 아래로 내릴 때 정상으로 돌아온다.
![ezgif com-gif-maker](https://user-images.githubusercontent.com/35067611/98922508-e0251680-2515-11eb-9b37-03d5c54d88d2.gif)

### 작업 유형
- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
